### PR TITLE
Simulation id and simulation manager

### DIFF
--- a/multimodal-server/log_manager.py
+++ b/multimodal-server/log_manager.py
@@ -1,21 +1,15 @@
 import os
-import datetime
 
 
-active_simulations = {}
+def register_log(simulation_id, message):
+    current_directory = os.path.dirname(os.path.abspath(__file__))
+    log_directory_name = "saved_logs"
+    log_directory_path = f"{current_directory}/{log_directory_name}"
+    file_name = f"{simulation_id}.txt"
+    file_path = f"{log_directory_path}/{file_name}"
 
-def register_log(simulation_name, log_message):
-    folder_name = "saved_logs"
-    os.makedirs(folder_name, exist_ok=True)
-
-    if simulation_name not in active_simulations:
-        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        unique_filename = f"{simulation_name}_{timestamp}.txt"
-        active_simulations[simulation_name] = unique_filename
-    else:
-        unique_filename = active_simulations[simulation_name]
-
-    file_path = os.path.join(folder_name, unique_filename)
+    if not os.path.exists(log_directory_path):
+        os.makedirs(log_directory_path)
 
     with open(file_path, "a") as file:
-        file.write(log_message + "\n")
+        file.write(message + "\n")

--- a/multimodal-server/server.py
+++ b/multimodal-server/server.py
@@ -1,212 +1,120 @@
 import logging
-import multiprocessing
 import os
 import time
 
-from flask import Flask, request
-from flask_socketio import SocketIO, emit, join_room, leave_room, rooms
-from simulation import run_simulation
-
-HOST = "127.0.0.1"
-PORT = 5000
-
-CLIENT_ROOM = "client"
-SIMULATION_ROOM = "simulation"
-SCRIPT_ROOM = "script"
-
-app = Flask(__name__)
-socketio = SocketIO(app, cors_allowed_origins="*")
-
-# key = session id, value = auth type
-sockets_types_by_session_id = dict()
-
-simulation_process_by_name = dict()
-simulation_session_id_by_name = dict()
-simulation_name_by_session_id = dict()
+from flask import Flask
+from flask_socketio import SocketIO, emit, join_room, leave_room
+from server_utils import CLIENT_ROOM, HOST, PORT, getSessionId, log
+from simulation_manager import SimulationManager
 
 
-# TODO Change with the real data
-def send_simulations():
-    emit(
-        "simulations",
-        [
-            {"name": name, "status": "running", "completion": 0, "data": "none"}
-            for name in simulation_process_by_name.keys()
-        ],
-        to=CLIENT_ROOM,
-    )
-
-
-def getSessionId():
-    return request.sid
-
-
-def log(message, auth_type, level=logging.INFO):
-    if auth_type == "server":
-        logging.log(level, f"[{auth_type}] {message}")
-    else:
-        logging.log(level, f"[{auth_type}] {getSessionId()} {message}")
-        emit("log", f"{level} [{auth_type}] {getSessionId()} {message}", to=CLIENT_ROOM)
-
-
-# MARK: Main events
-@socketio.on("connect")
-def on_connect(auth):
-    auth_type = auth["type"]
-    log("connected", auth_type)
-    sockets_types_by_session_id[getSessionId()] = auth_type
-    join_room(auth_type)
-
-
-@socketio.on("disconnect")
-def on_disconnect(reason):
-    auth_type = sockets_types_by_session_id.pop(getSessionId())
-    log(f"disconnected: {reason}", auth_type)
-    leave_room(auth_type)
-
-    # When a simulation client disconnects, we need to clean up the server
-    if auth_type == "simulation":
-        if not getSessionId() in simulation_name_by_session_id:
-            return
-        name = simulation_name_by_session_id.pop(getSessionId())
-        simulation_session_id_by_name.pop(name)
-        process = simulation_process_by_name.pop(name)
-        process.terminate()
-        process.join()
-        emit("simulationEnded", name, to=CLIENT_ROOM)
-        send_simulations()
-
-
-# MARK: Client events
-@socketio.on("startSimulation")
-def on_client_start_simulation(name):
-    # Check if a simulation with this name is already running
-    if name in simulation_process_by_name:
-        log(f"simulation {name} already running", "client")
-        emit("simulationAlreadyRunning", to=CLIENT_ROOM)
-        return
-
-    log(f"starting simulation {name}", "client")
-    simulation_process = multiprocessing.Process(target=run_simulation, args=(name,))
-    simulation_process.start()
-    simulation_process_by_name[name] = simulation_process
-
-
-@socketio.on("stopSimulation")
-def on_client_stop_simulation(name):
-    # Check if a simulation with this name is running
-    if name not in simulation_process_by_name:
-        log(f"simulation {name} not running", "client")
-        emit("simulationNotRunning", name, to=CLIENT_ROOM)
-        return
-
-    log(f"stopping simulation {name}", "client")
-    simulation_session_id = simulation_session_id_by_name[name]
-    emit("stopSimulation", to=simulation_session_id)
-
-
-@socketio.on("pauseSimulation")
-def on_client_pause_simulation(name):
-    if name not in simulation_process_by_name:
-        log(f"simulation {name} not running", "client")
-        emit("simulationNotRunning", name, to=CLIENT_ROOM)
-        return
-    # Le log de la simulation dit deja que c'est en pause
-    log(f"pausing simulation {name}", "client")
-    simulation_session_id = simulation_session_id_by_name[name]
-    emit("pauseSimulation", to=simulation_session_id)
-
-
-@socketio.on("resumeSimulation")
-def on_client_resume_simulation(name):
-    if name not in simulation_process_by_name:
-        log(f"simulation {name} not running", "client")
-        emit("simulationNotRunning", name, to=CLIENT_ROOM)
-        return
-
-    # Le log de la simulation dit deja que c'est resumed
-    log(f"resuming simulation {name}", "client")
-    simulation_session_id = simulation_session_id_by_name[name]
-    emit("resumeSimulation", to=simulation_session_id)
-
-
-@socketio.on("getSimulations")
-def on_client_get_simulations():
-    log("getting simulations", "client")
-    send_simulations()
-
-
-@socketio.on("getAvailableData")
-def on_client_get_data():
-    log("getting available data", "client")
-    current_dir = os.path.dirname(os.path.realpath(__file__))
-    data_dir = os.path.join(current_dir, "..", "data")
-    emit("availableData", os.listdir(data_dir), to=CLIENT_ROOM)
-
-
-# MARK: Script events
-@socketio.on("terminate")
-def on_script_terminate():
-    log("terminating server", "script")
-
-    # TODO Maybe not
-    # Terminate all running simulations
-    for name, process in simulation_process_by_name.items():
-        process.terminate()
-        process.join()
-
-    time.sleep(1)
-
-    socketio.stop()
-
-
-# MARK: Simulation events
-@socketio.on("simulationStart")
-def on_simulation_start(name):
-    log(f"simulation {name} started", "simulation")
-    emit("simulationStart", name, to=CLIENT_ROOM)
-    simulation_name_by_session_id[getSessionId()] = name
-    simulation_session_id_by_name[name] = getSessionId()
-    send_simulations()
-
-
-@socketio.on("simulationEnd")
-def on_simulation_end(name):
-    log(f"simulation {name} ended", "simulation")
-    emit("simulationEnd", name, to=CLIENT_ROOM)
-
-    simulation_session_id = simulation_name_by_session_id.pop(name)
-    simulation_name_by_session_id.pop(simulation_session_id)
-    simulation_process_by_name.pop(name)
-
-    send_simulations()
-
-
-@socketio.on("simulationPause")
-def on_simulation_pause(name):
-    log(f"simulation {name} paused", "simulation")
-    emit("simulationPause", name, to=CLIENT_ROOM)
-    send_simulations()
-
-
-@socketio.on("simulationResume")
-def on_simulation_resume(name):
-    log(f"simulation {name} resumed", "simulation")
-    emit("simulationResume", name, to=CLIENT_ROOM)
-    send_simulations()
-
-
-@socketio.on("log")
-def on_simulation_log_event(name, message):
-    log(f"simulation  {name}: {message}", "simulation")
-
-
-# MARK: Server
 def run_server():
-    logging.basicConfig(level=logging.INFO)
+    app = Flask(__name__)
 
-    log(f"Starting server at {HOST}:{PORT}", "server")
+    socketio = SocketIO(app, cors_allowed_origins="*")
 
+    # key = session id, value = auth type
+    sockets_types_by_session_id = dict()
+
+    simulation_manager = SimulationManager()
+
+    # MARK: Main events
+    @socketio.on("connect")
+    def on_connect(auth):
+        auth_type = auth["type"]
+        log("connected", auth_type)
+        sockets_types_by_session_id[getSessionId()] = auth_type
+        join_room(auth_type)
+
+    @socketio.on("disconnect")
+    def on_disconnect(reason):
+        session_id = getSessionId()
+        auth_type = sockets_types_by_session_id.pop(session_id)
+        log(f"disconnected: {reason}", auth_type)
+        leave_room(auth_type)
+
+        if auth_type == "simulation":
+            simulation_manager.on_simulation_disconnect(session_id)
+
+    # MARK: Client events
+    @socketio.on("startSimulation")
+    def on_client_start_simulation(name, data, response_event):
+        log(
+            f"starting simulation {name} with data {data} and response event {response_event}",
+            "client",
+        )
+        simulation_manager.start_simulation(name, data, response_event)
+
+    @socketio.on("stopSimulation")
+    def on_client_stop_simulation(simulation_id):
+        log(f"stopping simulation {simulation_id}", "client")
+        simulation_manager.stop_simulation(simulation_id)
+
+    @socketio.on("pauseSimulation")
+    def on_client_pause_simulation(simulation_id):
+        log(f"pausing simulation {simulation_id}", "client")
+        simulation_manager.pause_simulation(simulation_id)
+
+    @socketio.on("resumeSimulation")
+    def on_client_resume_simulation(simulation_id):
+        log(f"resuming simulation {simulation_id}", "client")
+        simulation_manager.resume_simulation(simulation_id)
+
+    @socketio.on("getSimulations")
+    def on_client_get_simulations():
+        log("getting simulations", "client")
+        simulation_manager.emit_simulations()
+
+    @socketio.on("getAvailableData")
+    def on_client_get_data():
+        log("getting available data", "client")
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        data_dir = os.path.join(current_dir, "..", "data")
+        emit("availableData", os.listdir(data_dir), to=CLIENT_ROOM)
+
+    # MARK: Script events
+    @socketio.on("terminate")
+    def on_script_terminate():
+        log("terminating server", "script")
+
+        for simulation_id, simulation_handler in simulation_manager.simulations.items():
+            if simulation_handler.process is not None:
+                simulation_handler.process.terminate()
+                simulation_handler.process.join()
+
+        time.sleep(1)
+
+        socketio.stop()
+
+    # MARK: Simulation events
+    @socketio.on("simulationStart")
+    def on_simulation_start(simulation_id):
+        log(f"simulation {simulation_id} started", "simulation")
+        simulation_manager.on_simulation_start(simulation_id, getSessionId())
+
+    @socketio.on("simulationEnd")
+    def on_simulation_end(simulation_id):
+        log(f"simulation {simulation_id} ended", "simulation")
+        simulation_manager.on_simulation_end(simulation_id)
+
+    @socketio.on("simulationPause")
+    def on_simulation_pause(simulation_id):
+        log(f"simulation {simulation_id} paused", "simulation")
+        simulation_manager.on_simulation_pause(simulation_id)
+
+    @socketio.on("simulationResume")
+    def on_simulation_resume(simulation_id):
+        log(f"simulation {simulation_id} resumed", "simulation")
+        simulation_manager.on_simulation_resume(simulation_id)
+
+    @socketio.on("log")
+    def on_simulation_log_event(simulation_id, message):
+        log(f"simulation  {simulation_id}: {message}", "simulation")
+        logging.basicConfig(level=logging.INFO)
+
+        log(f"Starting server at {HOST}:{PORT}", "server")
+
+    # MARK: Run server
     socketio.run(app, host=HOST, port=PORT)
 
 

--- a/multimodal-server/server_utils.py
+++ b/multimodal-server/server_utils.py
@@ -1,0 +1,23 @@
+import logging
+
+from flask import request
+from flask_socketio import emit
+
+HOST = "127.0.0.1"
+PORT = 5000
+
+CLIENT_ROOM = "client"
+SIMULATION_ROOM = "simulation"
+SCRIPT_ROOM = "script"
+
+
+def getSessionId():
+    return request.sid
+
+
+def log(message, auth_type, level=logging.INFO):
+    if auth_type == "server":
+        logging.log(level, f"[{auth_type}] {message}")
+    else:
+        logging.log(level, f"[{auth_type}] {getSessionId()} {message}")
+        emit("log", f"{level} [{auth_type}] {getSessionId()} {message}", to=CLIENT_ROOM)

--- a/multimodal-server/simulation_manager.py
+++ b/multimodal-server/simulation_manager.py
@@ -1,22 +1,265 @@
-class SimulationManager():
+import datetime
+import inspect
+import logging
+import multiprocessing
+from enum import Enum
+
+from flask_socketio import emit
+from server_utils import CLIENT_ROOM, log
+from simulation import run_simulation
+
+
+class SimulationStatus(Enum):
+    PAUSED = "paused"
+    RUNNING = "running"
+    COMPLETED = "completed"
+
+    """ The simulation has been abnormally stopped """
+    STOPPED = "stopped"
+
+
+class MinimalistSimulationConfiguration:
+    max_time: float | None
+    time_step: float | None
+    speed: float | None
+    update_position_time_step: float | None
+
+    def __init__(
+        self,
+        max_time: float | None,
+        time_step: float | None,
+        speed: float | None,
+        update_position_time_step: float | None,
+    ):
+        self.max_time = max_time
+        self.time_step = time_step
+        self.speed = speed
+        self.update_position_time_step = update_position_time_step
+
+
+class SimulationHandler:
+    simulation_id: str
+    name: str
+    start_time: float
+    data: str
+    process: multiprocessing.Process | None
+    status: SimulationStatus
+    socket_id: str | None
+    response_event: str | None
+
+    # TODO
+    # simulation_start_time: float | None
+    # expected_simulation_end_time: float | None
+    # configuration: MinimalistSimulationConfiguration
+    # completion: float | None
+
+    def __init__(
+        self,
+        simulation_id: str,
+        name: str,
+        start_time: float,
+        data: str,
+        status: SimulationStatus,
+        process: multiprocessing.Process | None = None,
+    ) -> None:
+        self.simulation_id = simulation_id
+        self.name = name
+        self.start_time = start_time
+        self.data = data
+        self.process = process
+        self.status = status
+
+        self.socket_id = None
+        self.response_event = None
+
+
+class SimulationManager:
+    simulations: dict[str, SimulationHandler]
 
     def __init__(self):
         self.simulations = {}
 
-    def start_simulation(self, name):
-        pass
+    def start_simulation(
+        self, name: str, data: str, response_event: str
+    ) -> SimulationHandler:
+        # Get the current time
+        start_time = datetime.datetime.now().strftime("%Y%m%d-%H%M%S%f")
+        # Remove microseconds
+        start_time = start_time[:-3]
 
-    def stop_simulation(self, name):
-        pass
+        # Start time first to sort easily
+        simulation_id = f"{start_time}-{name}"
 
-    def pause_simulation(self, name):
-        pass
+        simulation_process = multiprocessing.Process(
+            target=run_simulation, args=(simulation_id, data)
+        )
 
-    def resume_simulation(self, name):
-        pass
+        simulation_handler = SimulationHandler(
+            simulation_id,
+            name,
+            start_time,
+            data,
+            SimulationStatus.RUNNING,
+            simulation_process,
+        )
 
-    def get_simulations(self):
-        pass
+        simulation_handler.response_event = response_event
 
-    def get_simulation(self, name):
-        pass
+        self.simulations[simulation_id] = simulation_handler
+
+        simulation_process.start()
+
+        return simulation_handler
+
+    def on_simulation_start(self, simulation_id, socket_id):
+        if simulation_id not in self.simulations:
+            log(
+                f"{__file__} {inspect.currentframe().f_lineno}: Simulation {simulation_id} not found",
+                "server",
+                logging.ERROR,
+            )
+            return
+
+        simulation = self.simulations[simulation_id]
+
+        simulation.socket_id = socket_id
+
+        self.emit_simulations()
+
+        if simulation.response_event is not None:
+            log(f'Emitting response event "{simulation.response_event}"', "server")
+            emit(simulation.response_event, simulation_id, to=CLIENT_ROOM)
+            simulation.response_event = None
+
+    def stop_simulation(self, simulation_id):
+        if simulation_id not in self.simulations:
+            log(
+                f"{__file__} {inspect.currentframe().f_lineno}: Simulation {simulation_id} not found",
+                "server",
+                logging.ERROR,
+            )
+            return
+
+        simulation = self.simulations[simulation_id]
+
+        emit("stopSimulation", to=simulation.socket_id)
+
+    def on_simulation_end(self, simulation_id):
+        if simulation_id not in self.simulations:
+            log(
+                f"{__file__} {inspect.currentframe().f_lineno}: Simulation {simulation_id} not found",
+                "server",
+                logging.ERROR,
+            )
+            return
+
+        simulation = self.simulations[simulation_id]
+
+        simulation.status = SimulationStatus.COMPLETED
+
+        emit("canDisconnect", to=simulation.socket_id)
+
+        self.emit_simulations()
+
+    def pause_simulation(self, simulation_id):
+        if simulation_id not in self.simulations:
+            log(
+                f"{__file__} {inspect.currentframe().f_lineno}: Simulation {simulation_id} not found",
+                "server",
+                logging.ERROR,
+            )
+            return
+
+        simulation = self.simulations[simulation_id]
+
+        emit("pauseSimulation", to=simulation.socket_id)
+
+    def on_simulation_pause(self, simulation_id):
+        if simulation_id not in self.simulations:
+            log(
+                f"{__file__} {inspect.currentframe().f_lineno}: Simulation {simulation_id} not found",
+                "server",
+                logging.ERROR,
+            )
+            return
+
+        simulation = self.simulations[simulation_id]
+
+        simulation.status = SimulationStatus.PAUSED
+
+        self.emit_simulations()
+
+    def resume_simulation(self, simulation_id):
+        if simulation_id not in self.simulations:
+            log(
+                f"{__file__} {inspect.currentframe().f_lineno}: Simulation {simulation_id} not found",
+                "server",
+                logging.ERROR,
+            )
+            return
+
+        simulation = self.simulations[simulation_id]
+
+        emit("resumeSimulation", to=simulation.socket_id)
+
+    def on_simulation_resume(self, simulation_id):
+        if simulation_id not in self.simulations:
+            log(
+                f"{__file__} {inspect.currentframe().f_lineno}: Simulation {simulation_id} not found",
+                "server",
+                logging.ERROR,
+            )
+            return
+
+        simulation = self.simulations[simulation_id]
+
+        simulation.status = SimulationStatus.RUNNING
+
+        self.emit_simulations()
+
+    def on_simulation_disconnect(self, socket_id):
+        matching_simulation_ids = [
+            simulation_id
+            for simulation_id, simulation in self.simulations.items()
+            if simulation.socket_id == socket_id
+        ]
+
+        if len(matching_simulation_ids) != 1:
+            log(
+                f"{__file__} {inspect.currentframe().f_lineno}: Simulation not found",
+                "server",
+                logging.ERROR,
+            )
+            return
+
+        simulation_id = matching_simulation_ids[0]
+
+        simulation = self.simulations[simulation_id]
+
+        simulation.socket_id = None
+        simulation.process = None
+        simulation.response_event = None
+
+        if simulation.status == SimulationStatus.COMPLETED:
+            return
+
+        # If the simulation is not completed, it has been disconnected abnormally
+        simulation.status = SimulationStatus.STOPPED
+
+    def emit_simulations(self):
+        emit(
+            "simulations",
+            [
+                {
+                    "id": simulation.simulation_id,
+                    "name": simulation.name,
+                    "status": simulation.status.value,
+                    "startTime": simulation.start_time,
+                    "data": simulation.data,
+                }
+                for simulation in self.simulations.values()
+            ],
+            to=CLIENT_ROOM,
+        )
+
+        log("Emitting simulations", "server")

--- a/multimodal-ui/src/app/app.component.css
+++ b/multimodal-ui/src/app/app.component.css
@@ -27,7 +27,7 @@
 
   /* Make the buttons overlap the map */
   position: relative;
-  z-index: 4000;
+  z-index: 500;
 }
 
 #info-overlay {
@@ -37,7 +37,7 @@
   top: 0;
 
   margin: 20px; /* Matching .main margin */
-  z-index: 4000;
+  z-index: 500;
 }
 
 #info-content {
@@ -47,9 +47,9 @@
 
 app-connection-status {
   position: absolute;
-  /* 44px for the zoom control and a gap of 1rem */
-  right: calc(44px + 1rem);
-  bottom: 1rem;
+  /* 44px for the zoom control and a gap of 10px */
+  right: calc(44px + 10px);
+  bottom: 10px;
 
-  z-index: 4000;
+  z-index: 500;
 }

--- a/multimodal-ui/src/app/components/simulation-configuration-dialog/simulation-configuration-dialog.component.html
+++ b/multimodal-ui/src/app/components/simulation-configuration-dialog/simulation-configuration-dialog.component.html
@@ -1,4 +1,4 @@
-<!-- TODO Add Help -->
+<!-- TODO Add Help and validation -->
 <h2 mat-dialog-title>Configure Simulation</h2>
 
 <mat-dialog-content>
@@ -10,7 +10,7 @@
         <section class="flex-row gap-1-rem">
           <mat-form-field>
             <input matInput formControlName="name" />
-            <mat-label>Name TODO</mat-label>
+            <mat-label>Name</mat-label>
           </mat-form-field>
 
           <mat-form-field>
@@ -19,12 +19,12 @@
                 <mat-option [value]="data">{{ data }}</mat-option>
               }
             </mat-select>
-            <mat-label>Data TODO</mat-label>
+            <mat-label>Data</mat-label>
           </mat-form-field>
         </section>
 
         <mat-checkbox formControlName="shouldRunInBackground">
-          Run in background TODO
+          Run in background
         </mat-checkbox>
       </div>
     }
@@ -46,24 +46,24 @@
         <section class="flex-row gap-1-rem">
           <mat-form-field>
             <input type="number" matInput formControlName="maxTime" />
-            <mat-label>Max Time TODO</mat-label>
+            <mat-label>Max Time</mat-label>
           </mat-form-field>
 
           <mat-form-field>
             <input type="number" matInput formControlName="speed" />
-            <mat-label>Speed TODO</mat-label>
+            <mat-label>Speed</mat-label>
           </mat-form-field>
         </section>
 
         <section class="flex-row gap-1-rem">
           <mat-form-field>
             <input type="number" matInput formControlName="timeStep" />
-            <mat-label>Time Step TODO</mat-label>
+            <mat-label>Time Step</mat-label>
           </mat-form-field>
 
           <mat-form-field>
             <input type="number" matInput formControlName="positionTimeStep" />
-            <mat-label>Position Time Step TODO</mat-label>
+            <mat-label>Position Time Step</mat-label>
           </mat-form-field>
         </section>
       </div>

--- a/multimodal-ui/src/app/components/simulation-configuration-dialog/simulation-configuration-dialog.component.ts
+++ b/multimodal-ui/src/app/components/simulation-configuration-dialog/simulation-configuration-dialog.component.ts
@@ -26,12 +26,10 @@ import { DataService } from '../../services/data.service';
 
 export interface SimulationConfigurationDialogData {
   mode: 'start' | 'edit';
-  // TODO
   currentConfiguration: SimulationConfiguration | null;
 }
 
 export interface SimulationConfigurationDialogResult {
-  // TODO
   general: {
     name: string;
     data: string;
@@ -155,7 +153,6 @@ export class SimulationConfigurationDialogComponent implements OnDestroy {
   }
 
   onSave() {
-    // TODO
     if (this.formGroup.valid) {
       this.dialogRef.close(this.buildResult());
     } else {

--- a/multimodal-ui/src/app/components/simulation-control-bar/simulation-control-bar.component.html
+++ b/multimodal-ui/src/app/components/simulation-control-bar/simulation-control-bar.component.html
@@ -6,7 +6,7 @@
     <button
       mat-icon-button
       [matTooltip]="isPaused ? 'Resume the simulation' : 'Pause the simulation'"
-      (click)="togglePause(isPaused, simulation.name)"
+      (click)="togglePause(isPaused, simulation.id)"
     >
       <mat-icon>{{ isPausedSignal() ? "play_arrow" : "pause" }}</mat-icon>
     </button>

--- a/multimodal-ui/src/app/components/simulation-control-bar/simulation-control-bar.component.ts
+++ b/multimodal-ui/src/app/components/simulation-control-bar/simulation-control-bar.component.ts
@@ -47,12 +47,12 @@ export class SimulationControlBarComponent implements OnInit, OnDestroy {
     private readonly router: Router,
   ) {}
 
-  togglePause(wasPaused: boolean, name: string): void {
+  togglePause(wasPaused: boolean, id: string): void {
     this.isPausedSignal.update((previousValue) => !previousValue);
     if (wasPaused) {
-      this.communicationService.emit('resumeSimulation', name);
+      this.communicationService.emit('resumeSimulation', id);
     } else {
-      this.communicationService.emit('pauseSimulation', name);
+      this.communicationService.emit('pauseSimulation', id);
     }
   }
 
@@ -90,7 +90,7 @@ export class SimulationControlBarComponent implements OnInit, OnDestroy {
       return;
     }
 
-    // TODO
+    // TODO Update simulation configuration
   }
 
   async stopSimulation(simulation: Simulation) {
@@ -108,11 +108,7 @@ export class SimulationControlBarComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.communicationService.emit(
-      'stopSimulation',
-      // TODO Change this to id
-      simulation.name,
-    );
+    this.communicationService.emit('stopSimulation', simulation.id);
   }
 
   async leaveVisualization() {

--- a/multimodal-ui/src/app/components/simulation-list-dialog/simulation-list-dialog.component.html
+++ b/multimodal-ui/src/app/components/simulation-list-dialog/simulation-list-dialog.component.html
@@ -1,5 +1,6 @@
 <h2 mat-dialog-title>Configure Simulation</h2>
 
+<!-- TODO Edit configuration -->
 <mat-dialog-content>
   <h3>Actions</h3>
 
@@ -27,17 +28,19 @@
               class="light"
               [class.text-success]="simulation.status === 'running'"
               [class.text-warning]="simulation.status === 'paused'"
+              [class.text-error]="simulation.status === 'stopped'"
             >
-              {{ simulation.completion }}% - {{ simulation.status }}
+              {{ simulation.status }}
             </div>
           </div>
           <div class="actions align-self-end flex-row gap-0-5-rem">
             @if (simulation.status === "running") {
-              <!-- TODO -->
+              <!-- TODO Pause -->
               <button mat-icon-button [matTooltip]="'Pause'">
                 <mat-icon>pause</mat-icon>
               </button>
             } @else {
+              <!-- TODO Resume -->
               <button mat-icon-button [matTooltip]="'Resume'">
                 <mat-icon>play_arrow</mat-icon>
               </button>
@@ -82,10 +85,11 @@
             </div>
           </div>
           <div class="actions align-self-end flex-row gap-0-5-rem">
-            <!-- TODO -->
+            <!-- TODO Export -->
             <button mat-icon-button [matTooltip]="'Export'">
               <mat-icon>cloud_download</mat-icon>
             </button>
+            <!-- TODO Delete -->
             <button mat-icon-button [matTooltip]="'Delete'">
               <mat-icon>delete</mat-icon>
             </button>

--- a/multimodal-ui/src/app/components/simulation-list-dialog/simulation-list-dialog.component.ts
+++ b/multimodal-ui/src/app/components/simulation-list-dialog/simulation-list-dialog.component.ts
@@ -59,12 +59,10 @@ export class SimulationListDialogComponent {
 
   get runningSimulationsSignal(): Signal<Simulation[]> {
     return computed(() =>
-      this.simulationsSignal()
-        .filter(
-          (simulation) =>
-            simulation.status === 'running' || simulation.status === 'paused',
-        )
-        .sort((a, b) => a.completion - b.completion),
+      this.simulationsSignal().filter(
+        (simulation) =>
+          simulation.status === 'running' || simulation.status === 'paused',
+      ),
     );
   }
 
@@ -95,6 +93,6 @@ export class SimulationListDialogComponent {
       return;
     }
 
-    this.communicationService.emit('stopSimulation', simulation.name);
+    this.communicationService.emit('stopSimulation', simulation.id);
   }
 }

--- a/multimodal-ui/src/app/components/visualizer/visualizer.component.html
+++ b/multimodal-ui/src/app/components/visualizer/visualizer.component.html
@@ -5,13 +5,15 @@
   -->
   <mat-form-field class="search-bar enable-pointer-events">
     <input matInput />
-    <mat-label>Search in the simulation TODO</mat-label>
+    <!-- TODO Search -->
+    <mat-label>Search in the simulation</mat-label>
     <mat-icon matSuffix>search</mat-icon>
   </mat-form-field>
 
   <!-- MARK: Information Panel
     -->
   @if (shouldShowInformationPanelSignal()) {
+    <!-- TODO Fill panel -->
     <mat-card class="flex-column information-panel enable-pointer-events">
       <mat-card-content class="flex-1">
         <mat-card-title>Simulation Information</mat-card-title>

--- a/multimodal-ui/src/app/guards/load-active-simulation.guard.ts
+++ b/multimodal-ui/src/app/guards/load-active-simulation.guard.ts
@@ -8,7 +8,5 @@ export const loadActiveSimulationGuard: CanActivateFn = (route, state) => {
   const simulationService: SimulationService = inject(SimulationService);
 
   simulationService.setActiveSimulationId(simulationId);
-
-  console.log('Loading simulation', simulationId);
   return true;
 };

--- a/multimodal-ui/src/app/guards/unload-active-simulation.guard.ts
+++ b/multimodal-ui/src/app/guards/unload-active-simulation.guard.ts
@@ -11,7 +11,5 @@ export const unloadActiveSimulationGuard: CanDeactivateFn<unknown> = (
   const simulationService: SimulationService = inject(SimulationService);
 
   simulationService.unsetActiveSimulationId();
-
-  console.log('Unloading active simulation');
   return true;
 };

--- a/multimodal-ui/src/app/interfaces/simulation.model.ts
+++ b/multimodal-ui/src/app/interfaces/simulation.model.ts
@@ -1,13 +1,80 @@
+export type SimulationStatus = 'paused' | 'running' | 'completed' | 'stopped';
+
+export const SIMULATION_STATUSES: SimulationStatus[] = [
+  'paused',
+  'running',
+  'completed',
+  'stopped',
+];
+
 export interface Simulation {
+  /**
+   * The unique identifier of the simulation
+   */
+  id: string;
+
+  /**
+   * The name given to the simulation
+   */
   name: string;
+
+  /**
+   * The name of the data source that the simulation is using
+   */
   data: string;
-  completion: number;
-  status: 'paused' | 'running' | 'completed' | 'starting' | 'stopping';
+
+  /**
+   * An indicator of the progress of the simulation
+   */
+  // completion: number;
+
+  /**
+   * The current status of the simulation
+   */
+  status: SimulationStatus;
+
+  /**
+   * The real time at which the simulation was started
+   */
+  startTime: Date;
+
+  /**
+   * The time in the simulation at which the simulation starts
+   */
+  // simulationStartTime: number;
+
+  /**
+   * The time in the simulation at which the simulation ends
+   */
+  // expectedSimulationEndTime: number;
+
+  /**
+   * Current configuration of the simulation
+   *
+   * TODO Maybe change to an array of configurations to keep track of the changes in the configuration.
+   */
+  // configuration: SimulationConfiguration;
 }
 
 export interface SimulationConfiguration {
+  /**
+   * The time at which the simulation will be automatically stopped
+   */
   maxTime: number | null;
+
+  /**
+   * TODO I don't know what this is
+   * TODO Maybe remove the speed and always run at full speed
+   */
   speed: number | null;
+
+  /**
+   * The maximum time between two events in the simulation
+   */
   timeStep: number | null;
+
+  /**
+   * TODO I don't know what this is
+   */
   positionTimeStep: number | null;
 }

--- a/multimodal-ui/src/app/services/communication.service.ts
+++ b/multimodal-ui/src/app/services/communication.service.ts
@@ -26,9 +26,8 @@ export type CommunicationStatus = 'connected' | 'disconnected' | 'connecting';
   providedIn: 'root',
 })
 export class CommunicationService {
-  private readonly _communicationStatusSignal: WritableSignal<
-    'connected' | 'disconnected' | 'connecting'
-  > = signal('connecting');
+  private readonly _communicationStatusSignal: WritableSignal<CommunicationStatus> =
+    signal('connecting');
 
   private disconnectedDialogRef: MatDialogRef<
     InformationDialogComponent,
@@ -41,18 +40,6 @@ export class CommunicationService {
   ) {
     effect(() => {
       const communicationStatus = this._communicationStatusSignal();
-
-      switch (communicationStatus) {
-        case 'connected':
-          console.log('Connected to server');
-          break;
-        case 'disconnected':
-          console.log('Disconnected from server');
-          break;
-        case 'connecting':
-          console.log('Connecting to server');
-          break;
-      }
 
       if (communicationStatus === 'disconnected') {
         if (this.disconnectedDialogRef === null) {

--- a/multimodal-ui/src/app/services/data.service.ts
+++ b/multimodal-ui/src/app/services/data.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, Signal, signal, WritableSignal } from '@angular/core';
-import { Simulation } from '../interfaces/simulation.model';
+import {
+  Simulation,
+  SIMULATION_STATUSES,
+  SimulationStatus,
+} from '../interfaces/simulation.model';
 import { CommunicationService } from './communication.service';
 
 @Injectable({
@@ -33,7 +37,9 @@ export class DataService {
 
   private listen() {
     this.communicationService.on('simulations', (simulations) => {
-      this._simulationsSignal.set(simulations as Simulation[]);
+      this._simulationsSignal.set(
+        this.extractSimulations(simulations as Simulation[]),
+      );
     });
 
     this.communicationService.on('availableData', (availableData) => {
@@ -43,12 +49,96 @@ export class DataService {
     });
 
     this.communicationService.on('log', (data) => {
-      console.log(data);
+      console.debug(data);
     });
   }
 
   private query() {
     this.communicationService.emit('getSimulations');
     this.communicationService.emit('getAvailableData');
+  }
+
+  /**
+   * Validate and extract simulation data from the raw data.
+   */
+  private extractSimulations(data: Simulation[]): Simulation[] {
+    return data
+      .map((rawSimulation) => {
+        console.debug('Extracting simulation: ', rawSimulation);
+
+        if (!rawSimulation) {
+          console.error('Invalid simulation data: ', rawSimulation);
+          return null;
+        }
+
+        const id = rawSimulation['id'];
+        if (!id) {
+          console.error('Invalid simulation id: ', id);
+          return null;
+        }
+
+        const name: string = rawSimulation['name'];
+        if (!name) {
+          console.error('Invalid simulation name: ', name);
+          return null;
+        }
+
+        const data: string = rawSimulation['data'];
+        if (!data) {
+          console.error('Invalid simulation data: ', data);
+          return null;
+        }
+
+        const status: SimulationStatus = rawSimulation['status'];
+        if (!status) {
+          console.error('Invalid simulation status: ', status);
+          return null;
+        }
+        if (!SIMULATION_STATUSES.includes(status)) {
+          console.error('Simulation status not recognized: ', status);
+          return null;
+        }
+
+        const rawStartTime: string = rawSimulation[
+          'startTime'
+        ] as unknown as string;
+        if (!rawStartTime) {
+          console.error(`Invalid simulation start time: ${rawStartTime}`);
+          return null;
+        }
+
+        // Verify the format of the start time
+        if (!/^\d{8}-\d{9}$/.test(rawStartTime)) {
+          console.error(`Invalid format for start time: ${rawStartTime}`);
+          return null;
+        }
+
+        const year: number = parseInt(rawStartTime.slice(0, 4));
+        const month: number = parseInt(rawStartTime.slice(4, 6)) - 1;
+        const day: number = parseInt(rawStartTime.slice(6, 8));
+        const hours: number = parseInt(rawStartTime.slice(9, 11));
+        const minutes: number = parseInt(rawStartTime.slice(11, 13));
+        const seconds: number = parseInt(rawStartTime.slice(13, 15));
+        const milliseconds: number = parseInt(rawStartTime.slice(16, 19));
+
+        const startTime: Date = new Date(
+          year,
+          month,
+          day,
+          hours,
+          minutes,
+          seconds,
+          milliseconds,
+        );
+
+        return {
+          id,
+          name,
+          data,
+          status,
+          startTime,
+        };
+      })
+      .filter((simulation) => !!simulation);
   }
 }

--- a/multimodal-ui/src/app/services/simulation.service.ts
+++ b/multimodal-ui/src/app/services/simulation.service.ts
@@ -35,8 +35,7 @@ export class SimulationService {
       const simulations = this.dataService.simulationsSignal();
 
       const currentSimulation = simulations.find(
-        // TODO Change to id
-        (simulation) => simulation.name === activeSimulationId,
+        (simulation) => simulation.id === activeSimulationId,
       );
 
       return currentSimulation ?? null;


### PR DESCRIPTION
# Simulation id and simulation manager

## Modifications

- Add and use the id of the simulation.
- Create a simulation manager to centralize the logic of the communication between the server and the simulations.
- Modify the interactions between the server and a simulation : now the simulation end but wait for a response from the server before disconnecting to guarantee the reception of the last messages.
- Change of the access to files to now be independent from the location from which the server is run.
- Validate the simulations sent by the server to catch bugs while developing.
- Since the client does not have the id of the simulation it starts, we establish a temporary id that the server will use as event for a response when the simulation starts. The client will listen to this event to navigate to the visualization page.