### PR TITLE
Fix incomplete states

### DIFF
--- a/multimodal-server/server_utils.py
+++ b/multimodal-server/server_utils.py
@@ -14,7 +14,7 @@ CLIENT_ROOM = "client"
 SIMULATION_ROOM = "simulation"
 SCRIPT_ROOM = "script"
 
-# Save the state of the simulation every 500 events
+# Save the state of the simulation every STATE_SAVE_STEP events
 STATE_SAVE_STEP = 100
 
 # If the version is identical, the save file can be loaded

--- a/multimodal-server/simulation_visualization_data_model.py
+++ b/multimodal-server/simulation_visualization_data_model.py
@@ -1289,7 +1289,9 @@ class SimulationVisualizationDataManager:
             )
         )
 
-        all_states_files = os.listdir(folder_path)
+        all_states_files = [
+            path for path in os.listdir(folder_path) if path.endswith(".jsonl")
+        ]  # Filter out lock files
 
         states = []
         for state_file in all_states_files:
@@ -1400,10 +1402,8 @@ class SimulationVisualizationDataManager:
             order, state_timestamp = sorted_states[index]
 
             # If the client already has the state, skip it
-            # unless the simulation is not complete and the state is the last one
-            if order in loaded_state_orders and (
-                is_simulation_complete or index < len(sorted_states) - 1
-            ):
+            # except the last state that might have changed
+            if order in loaded_state_orders and not order == max(loaded_state_orders):
                 state_orders_to_keep.append(order)
 
                 all_state_indexes_in_client.append(index)

--- a/multimodal-ui/src/app/interfaces/simulation.model.ts
+++ b/multimodal-ui/src/app/interfaces/simulation.model.ts
@@ -514,8 +514,6 @@ export interface SimulationStates {
   } | null;
 }
 
-export const STATE_SAVE_STEP = 500;
-
 export function getAllStops(vehicle: Vehicle): Stop[] {
   return vehicle.previousStops.concat(
     vehicle.currentStop === null ? [] : [vehicle.currentStop],

--- a/multimodal-ui/src/app/services/simulation.service.ts
+++ b/multimodal-ui/src/app/services/simulation.service.ts
@@ -5,8 +5,8 @@ import {
   Signal,
   WritableSignal,
 } from '@angular/core';
-import { decode } from 'polyline';
 import randomName from 'node-random-name';
+import { decode } from 'polyline';
 import {
   AllPolylines,
   AnySimulationUpdate,
@@ -339,7 +339,7 @@ export class SimulationService {
       return null;
     }
 
-    let  name = data.name ?? null;
+    let name = data.name ?? null;
 
     if (name === id || name === null) {
       name = (randomName as (args?: { seed: string }) => string)({ seed: id });


### PR DESCRIPTION
# Fix incomplete states

When visualizing a running simulation, we sometimes could have incomplete states. This could occur when the client had the last state of the simulation incomplete because this was the most recent data, and when getting the new states, the simulation could have changed of state and the previous one would stay incomplete in the client.

## Modifications

- Filter lock files when getting all states.
- Always send the last state of the client to update it.