### PR TITLE
Keep default map tiles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,8 @@
   "python.defaultInterpreterPath": "\\venv\\Scripts\\python.exe",
   "cSpell.words": [
     "bluehalo",
+    "bottomleft",
+    "bottomright",
     "desync",
     "desynchronization",
     "DESYNCHRONIZATION",

--- a/multimodal-ui/src/app/components/map-tiles/map-tiles.component.html
+++ b/multimodal-ui/src/app/components/map-tiles/map-tiles.component.html
@@ -1,16 +1,20 @@
 <mat-card appearance="outlined">
   <mat-card-content>
     <p class="title">Map Tile Providers</p>
+
     <mat-chip-listbox class="chip-list" aria-label="Map Layers">
-      @for (tile of mapTiles(); track tile) {
+      @let selectedMapTile = selectedMapTileSignal();
+      @for (tile of mapTilesSignal(); track tile) {
+        @let isSelected = selectedMapTile === tile;
         <mat-chip-option
-          [selected]="selectedMapTile() === tile"
-          [selectable]="selectedMapTile() !== tile"
+          [selected]="isSelected"
+          [selectable]="!isSelected"
           (removed)="removeMapTile(tile)"
           (click)="setMapTile(tile)"
         >
           {{ tile.name }}
-          @if (tile.custom) {
+
+          @if (!tile.isDefault) {
             <button matChipRemove aria-label="'remove template form' + keyword">
               <mat-icon>cancel</mat-icon>
             </button>
@@ -18,6 +22,7 @@
         </mat-chip-option>
       }
     </mat-chip-listbox>
+
     <div class="btn-container">
       <button mat-button (click)="addMapTile()">Add Map Tile</button>
       <button mat-button (click)="editMapIcons()">Customize entities</button>

--- a/multimodal-ui/src/app/components/map-tiles/map-tiles.component.ts
+++ b/multimodal-ui/src/app/components/map-tiles/map-tiles.component.ts
@@ -24,16 +24,14 @@ import { MapService } from '../../services/map.service';
   styleUrl: './map-tiles.component.css',
 })
 export class MapLayersComponent {
-  mapTiles: Signal<MapTile[]>;
-  selectedMapTile: Signal<MapTile | null>;
+  mapTilesSignal: Signal<MapTile[]> = this.mapService.mapTilesSignal;
+  selectedMapTileSignal: Signal<MapTile | null> =
+    this.mapService.selectedMapTileSignal;
 
   constructor(
     readonly mapService: MapService,
     readonly dialogService: DialogService,
-  ) {
-    this.mapTiles = mapService.mapTiles;
-    this.selectedMapTile = mapService.selectedMapTile;
-  }
+  ) {}
 
   setMapTile(tile: MapTile) {
     this.mapService.selectMapTile(tile);

--- a/multimodal-ui/src/app/components/map/map.component.html
+++ b/multimodal-ui/src/app/components/map/map.component.html
@@ -1,7 +1,3 @@
-<div
-  class="map"
-  leaflet
-  [leafletOptions]="options"
-  (leafletMapReady)="onMapReady($event)"
-></div>
-<app-close-entities-menu></app-close-entities-menu>
+<div class="map" leaflet (leafletMapReady)="onMapReady($event)"></div>
+
+<app-close-entities-menu />

--- a/multimodal-ui/src/app/components/map/map.component.ts
+++ b/multimodal-ui/src/app/components/map/map.component.ts
@@ -1,6 +1,10 @@
-import { Component, inject, OnDestroy } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { LeafletModule } from '@bluehalo/ngx-leaflet';
-import { latLng, LatLngExpression, Map } from 'leaflet';
+import { latLng, Map } from 'leaflet';
+import {
+  MAP_CENTER_LOCAL_STORAGE_KEY,
+  MAP_ZOOM_LOCAL_STORAGE_KEY,
+} from '../../interfaces/local-storage';
 import { AnimationService } from '../../services/animation.service';
 import { MapService } from '../../services/map.service';
 import { CloseEntitiesMenuComponent } from '../close-entities-menu/close-entities-menu.component';
@@ -12,26 +16,12 @@ import { CloseEntitiesMenuComponent } from '../close-entities-menu/close-entitie
   styleUrl: './map.component.css',
 })
 export class MapComponent implements OnDestroy {
-  animationService: AnimationService = inject(AnimationService);
+  private map: Map | null = null;
 
-  // Retrieve saved zoom and position from localStorage
-  savedZoom = localStorage.getItem('mapZoom')
-    ? parseInt(localStorage.getItem('mapZoom')!, 10)
-    : 12;
-  savedCenter: LatLngExpression = localStorage.getItem('mapCenter')
-    ? (JSON.parse(localStorage.getItem('mapCenter')!) as [number, number])
-    : latLng(45.523066, -73.652687); // Montreal as Default
-
-  options = {
-    layers: [],
-
-    zoom: this.savedZoom,
-    center: this.savedCenter,
-  };
-
-  private map!: Map;
-
-  constructor(private readonly mapService: MapService) {
+  constructor(
+    private readonly mapService: MapService,
+    private readonly animationService: AnimationService,
+  ) {
     window.addEventListener('beforeunload', this.saveMapState.bind(this));
   }
 
@@ -43,30 +33,36 @@ export class MapComponent implements OnDestroy {
   onMapReady(map: Map) {
     this.map = map;
     this.mapService.map = map;
-    this.mapService.selectMapTile(this.mapService.selectedMapTile());
+    this.mapService.selectMapTile(this.mapService.selectedMapTileSignal());
 
     map.attributionControl.setPosition('bottomleft');
     map.zoomControl.setPosition('bottomright');
+
     this.animationService.addPixiOverlay(map);
 
-    if (this.savedZoom) {
-      map.setZoom(this.savedZoom);
-    }
-    if (this.savedCenter) {
-      map.setView(this.savedCenter, this.savedZoom);
-    }
+    const savedCenter = localStorage.getItem(MAP_CENTER_LOCAL_STORAGE_KEY);
+    const center = savedCenter
+      ? (JSON.parse(savedCenter) as [number, number])
+      : latLng(45.523066, -73.652687); // Montreal as Default
+
+    const savedZoom = localStorage.getItem(MAP_ZOOM_LOCAL_STORAGE_KEY);
+    const zoom = savedZoom ? parseInt(savedZoom, 10) : 12;
+
+    map.setView(center, zoom);
   }
 
   private saveMapState() {
-    if (this.map) {
-      const currentZoom = this.map.getZoom();
-      const currentCenter = this.map.getCenter();
-
-      localStorage.setItem('mapZoom', currentZoom.toString());
-      localStorage.setItem(
-        'mapCenter',
-        JSON.stringify([currentCenter.lat, currentCenter.lng]),
-      );
+    if (!this.map) {
+      return;
     }
+
+    const currentZoom = this.map.getZoom();
+    const currentCenter = this.map.getCenter();
+
+    localStorage.setItem(MAP_ZOOM_LOCAL_STORAGE_KEY, currentZoom.toString());
+    localStorage.setItem(
+      MAP_CENTER_LOCAL_STORAGE_KEY,
+      JSON.stringify([currentCenter.lat, currentCenter.lng]),
+    );
   }
 }

--- a/multimodal-ui/src/app/interfaces/local-storage.ts
+++ b/multimodal-ui/src/app/interfaces/local-storage.ts
@@ -1,0 +1,6 @@
+export const LOCAL_STORAGE_KEY = 'multimodal-viewer';
+
+export const MAP_LOCAL_STORAGE_KEY = LOCAL_STORAGE_KEY + '.map';
+
+export const MAP_CENTER_LOCAL_STORAGE_KEY = MAP_LOCAL_STORAGE_KEY + '.center';
+export const MAP_ZOOM_LOCAL_STORAGE_KEY = MAP_LOCAL_STORAGE_KEY + '.zoom';

--- a/multimodal-ui/src/app/interfaces/map.model.ts
+++ b/multimodal-ui/src/app/interfaces/map.model.ts
@@ -4,9 +4,9 @@ export interface MapTileSaveData {
   name: string;
   url: string;
   attribution: string | null;
-  custom: boolean;
 }
 
 export interface MapTile extends MapTileSaveData {
   tile: TileLayer;
+  isDefault: boolean;
 }

--- a/multimodal-ui/src/app/services/map.service.ts
+++ b/multimodal-ui/src/app/services/map.service.ts
@@ -12,71 +12,76 @@ import { MapTile, MapTileSaveData } from '../interfaces/map.model';
   providedIn: 'root',
 })
 export class MapService {
-  private readonly KEY_ADDED_TILES: string = 'multimodal.added-tiles';
-  private readonly KEY_SELECTED_TILE_INDEX: string =
+  private readonly ADDED_TILES_LOCAL_STORAGE_KEY: string =
+    'multimodal.added-tiles';
+  private readonly SELECTED_TILE_INDEX_LOCAL_STORAGE_KEY: string =
     'multimodal.selected-tile-index';
 
-  private readonly noWrap = true;
-  private readonly minZoom = 8;
-  private readonly maxZoom = 18;
+  private readonly NO_WRAP = true;
+  private readonly MINIMUM_ZOOM = 8;
+  private readonly MAXIMUM_ZOOM = 18;
 
-  map: Map | null = null;
+  private _map: Map | null = null;
 
-  private _selectedMapTile!: WritableSignal<MapTile>;
-  private _mapTiles: WritableSignal<MapTile[]> = signal([]);
+  private _selectedMapTileSignal: WritableSignal<MapTile | null> = signal(null);
+  private _mapTilesSignal: WritableSignal<MapTile[]> = signal([]);
 
-  get selectedMapTile(): Signal<MapTile> {
-    return this._selectedMapTile;
+  set map(map: Map) {
+    this._map = map;
   }
 
-  get mapTiles(): Signal<MapTile[]> {
-    return this._mapTiles;
+  get selectedMapTileSignal(): Signal<MapTile | null> {
+    return this._selectedMapTileSignal;
+  }
+
+  get mapTilesSignal(): Signal<MapTile[]> {
+    return this._mapTilesSignal;
   }
 
   constructor() {
     this.loadMapTilesData();
 
     effect(() => {
-      this.effectSaveMapTiles();
+      this.saveMapTilesEffect();
     });
 
     effect(() => {
-      this.effectUpdateIndex();
+      this.setIndexEffect();
     });
   }
 
-  selectMapTile(mapTile: MapTile) {
-    if (this.map == null) return;
+  selectMapTile(mapTile: MapTile | null) {
+    if (this._map == null || mapTile === null) return;
 
-    const selectedMapTile = this._selectedMapTile();
-    if (selectedMapTile !== undefined && selectedMapTile !== mapTile) {
-      this.map.removeLayer(selectedMapTile.tile);
+    const selectedMapTile = this._selectedMapTileSignal();
+    if (selectedMapTile !== null && selectedMapTile !== mapTile) {
+      this._map.removeLayer(selectedMapTile.tile);
     }
 
-    this._selectedMapTile.set(mapTile);
-    mapTile.tile.addTo(this.map);
+    this._selectedMapTileSignal.set(mapTile);
+    mapTile.tile.addTo(this._map);
   }
 
   addMapTile(name: string, url: string, attribution: string | null) {
-    this._mapTiles.update((mapTiles) => {
-      const newTile = this.createMapTile(name, url, attribution, true);
+    this._mapTilesSignal.update((mapTiles) => {
+      const newTile = this.createMapTile(name, url, attribution, false);
       return [...mapTiles, newTile];
     });
   }
 
   removeMapTile(tile: MapTile) {
-    this._mapTiles.update((mapTiles) => {
+    this._mapTilesSignal.update((mapTiles) => {
       return mapTiles.filter((mapTile) => mapTile !== tile);
     });
   }
 
-  private getDefaultTilesData() {
+  private getDefaultMapTiles() {
     const defaultMapTile = [
       this.createMapTile(
         'OpenStreetMap Standard',
         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-        false,
+        true,
       ),
       this.createMapTile(
         'Stadia Alidade Smooth Light',
@@ -97,29 +102,40 @@ export class MapService {
   }
 
   private loadMapTilesData() {
-    let tiles = this.loadSavedMapTiles();
-    if (tiles.length === 0) {
-      tiles = this.getDefaultTilesData();
-    }
+    const defaultMapTiles = this.getDefaultMapTiles();
+    const savedMapTiles = this.loadSavedMapTiles();
 
     const index = parseInt(
-      localStorage.getItem(this.KEY_SELECTED_TILE_INDEX) as string,
+      localStorage.getItem(
+        this.SELECTED_TILE_INDEX_LOCAL_STORAGE_KEY,
+      ) as string,
     );
 
-    if (!isNaN(index) && index < tiles.length) {
-      this._selectedMapTile = signal(tiles[index]);
+    const mapTiles = [...defaultMapTiles, ...savedMapTiles];
+
+    if (!isNaN(index) && index < mapTiles.length) {
+      this._selectedMapTileSignal = signal(mapTiles[index]);
     } else {
-      this._selectedMapTile = signal(tiles[0]);
+      this._selectedMapTileSignal = signal(mapTiles[0]);
     }
 
-    this._mapTiles.set(tiles);
+    this._mapTilesSignal.set(mapTiles);
   }
 
   private loadSavedMapTiles() {
-    const savedMapTilesJson = localStorage.getItem(this.KEY_ADDED_TILES);
+    const savedMapTilesJson = localStorage.getItem(
+      this.ADDED_TILES_LOCAL_STORAGE_KEY,
+    );
+
     if (savedMapTilesJson == null) return [];
 
     const savedMapTiles = JSON.parse(savedMapTilesJson) as MapTileSaveData[];
+
+    if (savedMapTiles.some((tile) => 'custom' in tile)) {
+      // Old format, clear localStorage
+      localStorage.removeItem(this.ADDED_TILES_LOCAL_STORAGE_KEY);
+      return [];
+    }
 
     const mapTiles = [];
     for (const savedMapTile of savedMapTiles) {
@@ -128,7 +144,7 @@ export class MapService {
           savedMapTile.name,
           savedMapTile.url,
           savedMapTile.attribution,
-          savedMapTile.custom,
+          false,
         ),
       );
     }
@@ -136,39 +152,50 @@ export class MapService {
     return mapTiles;
   }
 
-  private effectSaveMapTiles() {
-    const addedMapTiles = this._mapTiles();
-    const savedMapTiles: MapTileSaveData[] = addedMapTiles.map((tile) => {
-      return {
-        name: tile.name,
-        url: tile.url,
-        attribution: tile.attribution,
-        custom: tile.custom,
-      };
-    });
+  private saveMapTilesEffect() {
+    const savedMapTiles: MapTileSaveData[] = this.mapTilesSignal()
+      .filter((tile) => !tile.isDefault)
+      .map((tile) => {
+        return {
+          name: tile.name,
+          url: tile.url,
+          attribution: tile.attribution,
+        };
+      });
 
-    localStorage.setItem(this.KEY_ADDED_TILES, JSON.stringify(savedMapTiles));
+    localStorage.setItem(
+      this.ADDED_TILES_LOCAL_STORAGE_KEY,
+      JSON.stringify(savedMapTiles),
+    );
   }
 
-  private effectUpdateIndex() {
-    const selectedTile = this._selectedMapTile();
+  private setIndexEffect() {
+    const selectedTile = this.selectedMapTileSignal();
+
     if (selectedTile == null) return;
 
-    const mapTiles = this.mapTiles();
+    const mapTiles = this.mapTilesSignal();
+
+    if (mapTiles.length === 0) return;
+
     const index = mapTiles.findIndex((tile) => tile === selectedTile);
+
     if (index === -1) {
       this.selectMapTile(mapTiles[0]);
       return;
     }
 
-    localStorage.setItem(this.KEY_SELECTED_TILE_INDEX, index.toString());
+    localStorage.setItem(
+      this.SELECTED_TILE_INDEX_LOCAL_STORAGE_KEY,
+      index.toString(),
+    );
   }
 
   private createTileLayer(url: string, attribution: string | null): TileLayer {
     return tileLayer(url, {
-      noWrap: this.noWrap,
-      minZoom: this.minZoom,
-      maxZoom: this.maxZoom,
+      noWrap: this.NO_WRAP,
+      minZoom: this.MINIMUM_ZOOM,
+      maxZoom: this.MAXIMUM_ZOOM,
       attribution: attribution ?? undefined,
     });
   }
@@ -177,14 +204,14 @@ export class MapService {
     name: string,
     url: string,
     attribution: string | null,
-    custom: boolean,
+    isDefault: boolean,
   ): MapTile {
     return {
       name,
       url,
       attribution,
       tile: this.createTileLayer(url, attribution),
-      custom,
+      isDefault,
     };
   }
 }

--- a/multimodal-ui/tsconfig.json
+++ b/multimodal-ui/tsconfig.json
@@ -17,7 +17,8 @@
     "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
-    "module": "ES2022"
+    "module": "ES2022",
+    "useDefineForClassFields": false
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
# Keep default map tiles

## Modifications

- Clean up `MapComponent` and `MapService`.
- Keep the three default tiles.
- Do not save default tiles and always add them when loading from local storage.