### PR TITLE
Centralized timer service

### DIFF
--- a/multimodal-ui/src/app/components/simulation-control-bar/simulation-control-bar.component.html
+++ b/multimodal-ui/src/app/components/simulation-control-bar/simulation-control-bar.component.html
@@ -48,14 +48,14 @@
         x{{ speed }}
       </button>
       <mat-menu #speedMenu="matMenu" class="speed-menu">
-        <button mat-menu-item (click)="setSpeed(0)">x1</button>
-        <button mat-menu-item (click)="setSpeed(1)">x2</button>
-        <button mat-menu-item (click)="setSpeed(2)">x4</button>
-        <button mat-menu-item (click)="setSpeed(3)">x8</button>
-        <button mat-menu-item (click)="setSpeed(4)">x16</button>
-        <button mat-menu-item (click)="setSpeed(5)">x32</button>
-        <button mat-menu-item (click)="setSpeed(6)">x64</button>
-        <button mat-menu-item (click)="setSpeed(7)">x128</button>
+        <button mat-menu-item (click)="setSpeedPower(0)">x1</button>
+        <button mat-menu-item (click)="setSpeedPower(1)">x2</button>
+        <button mat-menu-item (click)="setSpeedPower(2)">x4</button>
+        <button mat-menu-item (click)="setSpeedPower(3)">x8</button>
+        <button mat-menu-item (click)="setSpeedPower(4)">x16</button>
+        <button mat-menu-item (click)="setSpeedPower(5)">x32</button>
+        <button mat-menu-item (click)="setSpeedPower(6)">x64</button>
+        <button mat-menu-item (click)="setSpeedPower(7)">x128</button>
       </mat-menu>
       <button
         mat-icon-button

--- a/multimodal-ui/src/app/components/simulation-control-bar/simulation-control-bar.component.ts
+++ b/multimodal-ui/src/app/components/simulation-control-bar/simulation-control-bar.component.ts
@@ -155,7 +155,6 @@ export class SimulationControlBarComponent implements OnInit, OnDestroy {
     effect(() => {
       const speed = this.speedSignal();
       this.visualizationService.setVisualizationSpeed(speed);
-      this.animationService.setSpeed(speed);
     });
 
     this.editorVisualisationTimeForm.valueChanges.subscribe((value) => {

--- a/multimodal-ui/src/app/components/simulation-control-bar/simulation-control-bar.component.ts
+++ b/multimodal-ui/src/app/components/simulation-control-bar/simulation-control-bar.component.ts
@@ -2,7 +2,6 @@ import { DecimalPipe } from '@angular/common';
 import {
   Component,
   computed,
-  effect,
   ElementRef,
   input,
   InputSignal,
@@ -36,6 +35,7 @@ import { Simulation } from '../../interfaces/simulation.model';
 import { SimulationTimePipe } from '../../pipes/simulation-time.pipe';
 import { AnimationService } from '../../services/animation.service';
 import { SimulationService } from '../../services/simulation.service';
+import { TimerService } from '../../services/timer.service';
 import { VisualizationService } from '../../services/visualization.service';
 import { simulationTimeDisplay } from '../../utils/simulation-time.utils';
 
@@ -65,20 +65,17 @@ export class SimulationControlBarComponent implements OnInit, OnDestroy {
   sliderTooltipX = 0;
 
   // MARK: Properties
-  readonly isSimulationPausedSignal: Signal<boolean> = computed(
-    () => this.simulationInputSignal().status === 'paused',
-  );
   readonly MIN_SPEED_POWER = 0;
   readonly MAX_SPEED_POWER = 7;
   readonly FAST_FORWARD_STEP = 1;
 
-  private readonly speedPowerSignal: WritableSignal<number> = signal(0);
+  readonly isVisualizationPausedSignal = this.timerService.isPausedSignal;
 
-  private readonly speedDirectionSignal: WritableSignal<number> = signal(1);
+  readonly speedPowerSignal = this.timerService.speedPowerSignal;
 
-  readonly speedSignal: Signal<number> = computed(
-    () => Math.pow(2, this.speedPowerSignal()) * this.speedDirectionSignal(),
-  );
+  readonly speedDirectionSignal = this.timerService.directionSignal;
+
+  readonly speedSignal = this.timerService.speedSignal;
 
   readonly fastForwardStepSignal: Signal<number> = computed(() => {
     return Math.abs(this.speedSignal()) * this.FAST_FORWARD_STEP;
@@ -151,12 +148,8 @@ export class SimulationControlBarComponent implements OnInit, OnDestroy {
     private readonly visualizationService: VisualizationService,
     private readonly animationService: AnimationService,
     private readonly simulationService: SimulationService,
+    private readonly timerService: TimerService,
   ) {
-    effect(() => {
-      const speed = this.speedSignal();
-      this.visualizationService.setVisualizationSpeed(speed);
-    });
-
     this.editorVisualisationTimeForm.valueChanges.subscribe((value) => {
       this.editorVisualisationTimeValueSignal.set(
         value ? parseInt(value) : NaN,
@@ -164,7 +157,7 @@ export class SimulationControlBarComponent implements OnInit, OnDestroy {
     });
 
     hotkeys('space', () => {
-      this.toggleVisualizationPause(this.isVisualizationPausedSignal());
+      this.toggleVisualizationPause(this.timerService.isPausedSignal());
     });
 
     hotkeys('ctrl+left,command+left,cmd+left', () => {
@@ -176,11 +169,11 @@ export class SimulationControlBarComponent implements OnInit, OnDestroy {
     });
 
     hotkeys('ctrl+up,command+up,cmd+up', () => {
-      this.increaseSpeed();
+      this.increaseSpeedPower();
     });
 
     hotkeys('ctrl+down,command+down,cmd+down', () => {
-      this.decreaseSpeed();
+      this.decreaseSpeedPower();
     });
 
     hotkeys('r', () => {
@@ -225,36 +218,30 @@ export class SimulationControlBarComponent implements OnInit, OnDestroy {
     return this.visualizationService.visualizationMaxTimeSignal;
   }
 
-  get isVisualizationPausedSignal(): Signal<boolean> {
-    return this.visualizationService.isVisualizationPausedSignal;
-  }
-
   get shouldFollowEntitySignal(): Signal<boolean> {
     return this.animationService.shouldFollowEntitySignal;
   }
 
   // MARK: Handlers
   toggleVisualizationPause(wasPaused: boolean): void {
-    if (wasPaused) {
-      this.visualizationService.resumeVisualization();
-    } else {
-      this.visualizationService.pauseVisualization();
-    }
+    this.timerService.isPaused = !wasPaused;
   }
 
-  setSpeed(speed: number): void {
-    this.speedPowerSignal.set(speed);
+  setSpeedPower(value: number): void {
+    this.timerService.speedPower = value;
   }
 
-  decreaseSpeed(): void {
-    this.speedPowerSignal.update((power) =>
-      Math.max(power - 1, this.MIN_SPEED_POWER),
+  decreaseSpeedPower(): void {
+    this.timerService.speedPower = Math.max(
+      this.timerService.speedPowerSignal() - 1,
+      this.MIN_SPEED_POWER,
     );
   }
 
-  increaseSpeed(): void {
-    this.speedPowerSignal.update((power) =>
-      Math.min(power + 1, this.MAX_SPEED_POWER),
+  increaseSpeedPower(): void {
+    this.timerService.speedPower = Math.min(
+      this.timerService.speedPowerSignal() + 1,
+      this.MAX_SPEED_POWER,
     );
   }
 
@@ -300,7 +287,7 @@ export class SimulationControlBarComponent implements OnInit, OnDestroy {
   }
 
   toggleSimulationDirection(): void {
-    this.speedDirectionSignal.update((direction) => -direction);
+    this.timerService.direction = -this.timerService.directionSignal();
   }
 
   centerMap() {

--- a/multimodal-ui/src/app/components/simulation-control-panel/simulation-control-panel.component.ts
+++ b/multimodal-ui/src/app/components/simulation-control-panel/simulation-control-panel.component.ts
@@ -37,6 +37,9 @@ export class SimulationControlPanelComponent {
     () => this.simulationInputSignal().status === 'paused',
   );
 
+  readonly isInitializedSignal: Signal<boolean> =
+    this.visualizationService.isInitializedSignal;
+
   // MARK: Inputs
   readonly simulationInputSignal: InputSignal<Simulation> =
     input.required<Simulation>({ alias: 'simulation' });
@@ -56,15 +59,6 @@ export class SimulationControlPanelComponent {
 
   // MARK: Constructor
   constructor(private readonly visualizationService: VisualizationService) {}
-
-  // MARK: Getters
-  get isInitializedSignal(): Signal<boolean> {
-    return this.visualizationService.isInitializedSignal;
-  }
-
-  get isVisualizationPausedSignal(): Signal<boolean> {
-    return this.visualizationService.isVisualizationPausedSignal;
-  }
 
   // MARK: Handlers
   toggleSimulationPause(wasPaused: boolean, id: string): void {

--- a/multimodal-ui/src/app/components/visualizer/visualizer.component.ts
+++ b/multimodal-ui/src/app/components/visualizer/visualizer.component.ts
@@ -43,7 +43,7 @@ import { CommunicationService } from '../../services/communication.service';
 import { DialogService } from '../../services/dialog.service';
 import { LoadingService } from '../../services/loading.service';
 import { SimulationService } from '../../services/simulation.service';
-import { TaskService } from '../../services/task.service';
+import { TimerService } from '../../services/timer.service';
 import { UserInterfaceService } from '../../services/user-interface.service';
 import { VisualizationFilterService } from '../../services/visualization-filter.service';
 import { VisualizationService } from '../../services/visualization.service';
@@ -530,6 +530,8 @@ export class VisualizerComponent implements OnDestroy {
   readonly entitySearchDisplayFunction = (entity: EntitySearch) =>
     entity?.displayedValue ?? '';
 
+  readonly isLoadingSignal = this.timerService.isLoadingSignal;
+
   // MARK: Constructor
   constructor(
     private readonly simulationService: SimulationService,
@@ -542,7 +544,7 @@ export class VisualizerComponent implements OnDestroy {
     private readonly visualizationService: VisualizationService,
     private readonly formBuilder: FormBuilder,
     private readonly visualizationFilterService: VisualizationFilterService,
-    private readonly taskService: TaskService,
+    private readonly timerService: TimerService,
   ) {
     this.tabControl = new FormControl('');
     this.tabControl.valueChanges.subscribe((value) => {
@@ -657,12 +659,6 @@ export class VisualizerComponent implements OnDestroy {
           this.searchInput.nativeElement.click();
         });
       }
-    });
-
-    effect(() => {
-      const isVisualizationPausedSignal =
-        this.visualizationService.isVisualizationPausedSignal();
-      this.animationService.setPause(isVisualizationPausedSignal);
     });
 
     effect(() => {
@@ -864,10 +860,6 @@ export class VisualizerComponent implements OnDestroy {
 
   get simulationSignal(): Signal<Simulation | null> {
     return this.simulationService.activeSimulationSignal;
-  }
-
-  get isLoadingSignal(): Signal<boolean> {
-    return this.visualizationService.isLoadingSignal;
   }
 
   // MARK: Handlers

--- a/multimodal-ui/src/app/interfaces/continuous.model.ts
+++ b/multimodal-ui/src/app/interfaces/continuous.model.ts
@@ -1033,6 +1033,12 @@ export function isIntervalCovered(
   start: number,
   end: number,
 ): boolean {
+  if (start >= end) {
+    const temp = start;
+    start = end;
+    end = temp;
+  }
+
   if (continuousEnvironments.length === 0) {
     return false;
   }

--- a/multimodal-ui/src/app/interfaces/local-storage.ts
+++ b/multimodal-ui/src/app/interfaces/local-storage.ts
@@ -1,6 +1,168 @@
-export const LOCAL_STORAGE_KEY = 'multimodal-viewer';
+const LOCAL_STORAGE_KEY = 'multimodal-viewer';
 
-export const MAP_LOCAL_STORAGE_KEY = LOCAL_STORAGE_KEY + '.map';
+// MARK: Map
+const MAP_LOCAL_STORAGE_KEY = LOCAL_STORAGE_KEY + '.map';
 
 export const MAP_CENTER_LOCAL_STORAGE_KEY = MAP_LOCAL_STORAGE_KEY + '.center';
 export const MAP_ZOOM_LOCAL_STORAGE_KEY = MAP_LOCAL_STORAGE_KEY + '.zoom';
+
+// MARK: Visualization
+const VISUALIZATION_LOCAL_STORAGE_KEY_PREFIX =
+  LOCAL_STORAGE_KEY + '.visualization';
+
+function getVisualizationLocalStorageKey(simulationId: string) {
+  return VISUALIZATION_LOCAL_STORAGE_KEY_PREFIX + `.${simulationId}`;
+}
+
+const VISUALIZATION_IS_PAUSED_LOCAL_STORAGE_KEY_SUFFIX = '.is-paused';
+const VISUALIZATION_SPEED_POWER_LOCAL_STORAGE_KEY_SUFFIX = '.speed-power';
+const VISUALIZATION_DIRECTION_LOCAL_STORAGE_KEY_SUFFIX = '.direction';
+const VISUALIZATION_TIME_LOCAL_STORAGE_KEY_SUFFIX = '.time';
+
+function getVisualizationIsPausedLocalStorageKey(simulationId: string) {
+  return (
+    getVisualizationLocalStorageKey(simulationId) +
+    VISUALIZATION_IS_PAUSED_LOCAL_STORAGE_KEY_SUFFIX
+  );
+}
+
+export function setVisualizationIsPausedLocalStorage(
+  simulationId: string,
+  isPaused: boolean,
+) {
+  localStorage.setItem(
+    getVisualizationIsPausedLocalStorageKey(simulationId),
+    JSON.stringify(isPaused),
+  );
+}
+
+export function getVisualizationIsPausedLocalStorage(
+  simulationId: string,
+): boolean | null {
+  const savedIsPaused = localStorage.getItem(
+    getVisualizationIsPausedLocalStorageKey(simulationId),
+  );
+
+  if (savedIsPaused === null) {
+    return null;
+  }
+
+  const isPaused: unknown = JSON.parse(savedIsPaused);
+
+  if (typeof isPaused === 'boolean') {
+    return isPaused;
+  }
+
+  return null;
+}
+
+function getVisualizationSpeedPowerLocalStorageKey(simulationId: string) {
+  return (
+    getVisualizationLocalStorageKey(simulationId) +
+    VISUALIZATION_SPEED_POWER_LOCAL_STORAGE_KEY_SUFFIX
+  );
+}
+
+export function setVisualizationSpeedPowerLocalStorage(
+  simulationId: string,
+  speed: number,
+) {
+  localStorage.setItem(
+    getVisualizationSpeedPowerLocalStorageKey(simulationId),
+    JSON.stringify(speed),
+  );
+}
+
+export function getVisualizationSpeedPowerLocalStorage(
+  simulationId: string,
+): number | null {
+  const savedSpeed = localStorage.getItem(
+    getVisualizationSpeedPowerLocalStorageKey(simulationId),
+  );
+
+  if (savedSpeed === null) {
+    return null;
+  }
+
+  const speed: unknown = JSON.parse(savedSpeed);
+
+  if (typeof speed === 'number') {
+    return speed;
+  }
+
+  return null;
+}
+
+function getVisualizationDirectionLocalStorageKey(simulationId: string) {
+  return (
+    getVisualizationLocalStorageKey(simulationId) +
+    VISUALIZATION_DIRECTION_LOCAL_STORAGE_KEY_SUFFIX
+  );
+}
+
+export function setVisualizationDirectionLocalStorage(
+  simulationId: string,
+  direction: number,
+) {
+  localStorage.setItem(
+    getVisualizationDirectionLocalStorageKey(simulationId),
+    JSON.stringify(direction),
+  );
+}
+
+export function getVisualizationDirectionLocalStorage(
+  simulationId: string,
+): number | null {
+  const savedDirection = localStorage.getItem(
+    getVisualizationDirectionLocalStorageKey(simulationId),
+  );
+
+  if (savedDirection === null) {
+    return null;
+  }
+
+  const direction: unknown = JSON.parse(savedDirection);
+
+  if (typeof direction === 'number') {
+    return direction;
+  }
+
+  return null;
+}
+
+function getVisualizationTimeLocalStorageKey(simulationId: string) {
+  return (
+    getVisualizationLocalStorageKey(simulationId) +
+    VISUALIZATION_TIME_LOCAL_STORAGE_KEY_SUFFIX
+  );
+}
+
+export function setVisualizationTimeLocalStorage(
+  simulationId: string,
+  time: number,
+) {
+  localStorage.setItem(
+    getVisualizationTimeLocalStorageKey(simulationId),
+    JSON.stringify(time),
+  );
+}
+
+export function getVisualizationTimeLocalStorage(
+  simulationId: string,
+): number | null {
+  const savedTime = localStorage.getItem(
+    getVisualizationTimeLocalStorageKey(simulationId),
+  );
+
+  if (savedTime === null) {
+    return null;
+  }
+
+  const time: unknown = JSON.parse(savedTime);
+
+  if (typeof time === 'number') {
+    return time;
+  }
+
+  return null;
+}

--- a/multimodal-ui/src/app/services/animation.service.ts
+++ b/multimodal-ui/src/app/services/animation.service.ts
@@ -31,7 +31,6 @@ import {
   isAnimatedVehicle,
 } from '../interfaces/animation.model';
 import {
-  ContinuousEnvironment,
   EnvironmentSlice,
   findClosestContinuousEnvironment,
   isIntervalCovered,
@@ -45,13 +44,14 @@ import { getAllStops, Vehicle } from '../interfaces/vehicle.model';
 import { FavoriteEntitiesService } from './favorite-entities.service';
 import { SpritesService } from './sprites.service';
 import { TaskService } from './task.service';
+import { TimerService } from './timer.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AnimationService {
   // MARK: Constants
-  private readonly MAXIMUM_ALLOWED_DESYNCHRONIZATION_DIFFERENCE = 1.5;
+  private readonly MAXIMUM_ANIMATION_JUMP = 30 / 1000; // ms
 
   private readonly WHITE = 0xffffff;
 
@@ -76,11 +76,8 @@ export class AnimationService {
   // MARK: Properties
 
   // Use two variables to avoid changing the ones used for the animation during the animation
-  private nextContinuousEnvironments: ContinuousEnvironment[] = [];
-  private nextWantedVisualizationTime: number | null = null;
   private nextPolylines: AllPolylines | null = null;
   private nextIsPaused = false;
-  private nextSpeed = 1;
   private nextFilters: Set<string> = new Set<string>();
   private nextFilterMode: EntityFilterMode = 'all';
   private nextShouldShowComplete = false;
@@ -90,9 +87,6 @@ export class AnimationService {
   private nextHighlightedLegIndex: number | null = null;
   private nextShouldFindCloseEntities = false;
 
-  private continuousEnvironments: ContinuousEnvironment[] = [];
-
-  private wantedVisualizationTime: number | null = null;
   private animationVisualizationTime = 0;
 
   private polylines: AllPolylines | null = null;
@@ -100,7 +94,6 @@ export class AnimationService {
   private hasCenteredInitially = false;
 
   private isPaused = false;
-  private speed = 1;
 
   private vehicleEntities: AnimatedVehicle[] = [];
   private vehicleEntitiesByVehicleId: Record<string, AnimatedVehicle> = {};
@@ -159,6 +152,7 @@ export class AnimationService {
     private readonly favoriteEntitiesService: FavoriteEntitiesService,
     private readonly spritesService: SpritesService,
     private readonly taskService: TaskService,
+    private readonly timerService: TimerService,
   ) {
     void Assets.load(this.BITMAP_TEXT_URL).then(() => {
       this.fontsLoaded = true;
@@ -213,10 +207,6 @@ export class AnimationService {
     this.nextShouldShowComplete = shouldShowComplete;
   }
 
-  setSpeed(speed: number) {
-    this.nextSpeed = speed;
-  }
-
   toggleShouldFollowEntity() {
     this.nextShouldFollowEntity = !this.nextShouldFollowEntity;
   }
@@ -265,24 +255,13 @@ export class AnimationService {
   }
 
   // MARK: Public Methods
-  updateEnvironment(continuousEnvironments: ContinuousEnvironment[]) {
-    this.nextContinuousEnvironments = continuousEnvironments;
-  }
-
-  updateWantedVisualizationTime(wantedVisualizationTime: number | null): void {
-    this.nextWantedVisualizationTime = wantedVisualizationTime;
-  }
-
   updatePolylines(polylines: AllPolylines | null) {
     this.nextPolylines = polylines;
   }
 
   clearAnimations() {
-    this.nextContinuousEnvironments = [];
-    this.nextWantedVisualizationTime = null;
     this.nextPolylines = null;
     this.nextIsPaused = false;
-    this.nextSpeed = 1;
     this.nextFilters.clear();
     this.nextFilterMode = 'all';
     this.nextShouldShowComplete = false;
@@ -291,9 +270,6 @@ export class AnimationService {
     this.nextClickEvent = null;
     this.nextHighlightedLegIndex = null;
 
-    this.continuousEnvironments = [];
-
-    this.wantedVisualizationTime = null;
     this.animationVisualizationTime = 0;
 
     this.polylines = null;
@@ -301,7 +277,6 @@ export class AnimationService {
     this.hasCenteredInitially = false;
 
     this.isPaused = false;
-    this.speed = 1;
 
     this.vehicleEntities = [];
     this.vehicleEntitiesByVehicleId = {};
@@ -387,11 +362,8 @@ export class AnimationService {
   private onRedraw(utils: PixiOverlayUtils) {
     if (!this.fontsLoaded) return;
 
-    this.continuousEnvironments = this.nextContinuousEnvironments;
-    this.wantedVisualizationTime = this.nextWantedVisualizationTime;
     this.polylines = this.nextPolylines;
     this.isPaused = this.nextIsPaused;
-    this.speed = this.nextSpeed;
     this.filters = this.nextFilters;
     this.filterMode = this.nextFilterMode;
     this.shouldShowComplete = this.nextShouldShowComplete;
@@ -402,33 +374,17 @@ export class AnimationService {
     this.shouldFindCloseEntities = this.nextShouldFindCloseEntities;
     this._shouldFollowEntitySignal.set(this.nextShouldFollowEntity);
 
-    if (this.wantedVisualizationTime === null) {
-      return; // Unknown wanted visualization time
-    }
-
-    if (this.continuousEnvironments.length === 0) {
-      return; // No continuous environments available
-    }
-
     if (this.polylines === null) {
       return; // No polylines available
     }
 
     this.updateAnimationTime();
 
-    const continuousEnvironment = findClosestContinuousEnvironment(
-      this.continuousEnvironments,
-      this.animationVisualizationTime,
-    );
+    const environment = this.updateEnvironment();
 
-    if (continuousEnvironment === null) {
-      return; // Environment not available
+    if (environment === null) {
+      return; // No environment available
     }
-
-    const environment = sliceEnvironment(
-      continuousEnvironment,
-      this.animationVisualizationTime,
-    );
 
     this.spritesService.calculateSpriteScales(utils);
 
@@ -455,42 +411,62 @@ export class AnimationService {
   }
 
   private updateAnimationTime() {
-    if (this.wantedVisualizationTime === null) {
+    const elapsedTime = this.timerService.updateTime();
+    const visualizationTime = this.timerService.visualizationTime;
+    const continuousEnvironments = this.timerService.continuousEnvironments;
+
+    if (visualizationTime === null || elapsedTime === null) {
       return; // Unknown wanted visualization time
     }
 
     // Verify that there is a continuous path from the current time to the wanted time
-    const minimum = Math.min(
-      this.wantedVisualizationTime,
-      this.animationVisualizationTime,
-    );
-    const maximum = Math.max(
-      this.wantedVisualizationTime,
-      this.animationVisualizationTime,
-    );
-    if (!isIntervalCovered(this.continuousEnvironments, minimum, maximum)) {
-      this.animationVisualizationTime = this.wantedVisualizationTime;
-      return; // No continuous path from current time to wanted time
+    if (
+      !isIntervalCovered(
+        continuousEnvironments,
+        visualizationTime,
+        this.animationVisualizationTime,
+      )
+    ) {
+      this.animationVisualizationTime = visualizationTime; // Jump to wanted time
+      return;
     }
 
-    const deltaSeconds = Ticker.shared.deltaMS / 1000;
-
-    if (!this.isPaused) {
-      this.animationVisualizationTime += deltaSeconds * this.speed;
-    } else {
-      this.animationVisualizationTime = this.wantedVisualizationTime;
+    if (this.isPaused) {
+      this.animationVisualizationTime = visualizationTime; // Jump to wanted time
+      return;
     }
 
     const desynchronizationDifference =
-      this.wantedVisualizationTime - this.animationVisualizationTime;
+      visualizationTime - this.animationVisualizationTime;
+
     if (
       Math.abs(desynchronizationDifference) >
-      this.MAXIMUM_ALLOWED_DESYNCHRONIZATION_DIFFERENCE * this.speed
+      this.MAXIMUM_ANIMATION_JUMP * this.timerService.speed
     ) {
+      // Accelerate to catch up
       this.animationVisualizationTime +=
-        desynchronizationDifference *
-        (1 - Math.exp(-5 * Math.abs(deltaSeconds)));
+        desynchronizationDifference * (1 - Math.exp(-5 * elapsedTime));
+    } else {
+      this.animationVisualizationTime = visualizationTime;
     }
+  }
+
+  private updateEnvironment(): EnvironmentSlice | null {
+    const continuousEnvironments = this.timerService.continuousEnvironments;
+
+    const closestContinuousEnvironment = findClosestContinuousEnvironment(
+      continuousEnvironments,
+      this.animationVisualizationTime,
+    );
+
+    if (closestContinuousEnvironment === null) {
+      return null;
+    }
+
+    return sliceEnvironment(
+      closestContinuousEnvironment,
+      this.animationVisualizationTime,
+    );
   }
 
   private onClick(event: LeafletMouseEvent) {

--- a/multimodal-ui/src/app/services/animation.service.ts
+++ b/multimodal-ui/src/app/services/animation.service.ts
@@ -441,7 +441,9 @@ export class AnimationService {
         Math.abs(
           this.timerService.speedSignal() * this.MAXIMUM_ANIMATION_JUMP_SECONDS,
         ) +
-        (absoluteDifference - this.MAXIMUM_ANIMATION_JUMP_SECONDS) *
+        (absoluteDifference -
+          this.MAXIMUM_ANIMATION_JUMP_SECONDS *
+            this.timerService.speedSignal()) *
           (1 - Math.exp(-5 * elapsedTime));
 
       this.animationVisualizationTime += catchUp * direction;

--- a/multimodal-ui/src/app/services/animation.service.ts
+++ b/multimodal-ui/src/app/services/animation.service.ts
@@ -51,7 +51,7 @@ import { TimerService } from './timer.service';
 })
 export class AnimationService {
   // MARK: Constants
-  private readonly MAXIMUM_ANIMATION_JUMP = 30 / 1000; // 0.03 seconds (30 ms)
+  private readonly MAXIMUM_ANIMATION_JUMP_SECONDS = 30 / 1000; // 0.03 seconds (30 ms)
 
   private readonly WHITE = 0xffffff;
 
@@ -430,11 +430,17 @@ export class AnimationService {
 
     if (
       Math.abs(desynchronizationDifference) >
-      this.MAXIMUM_ANIMATION_JUMP * this.timerService.speedSignal()
+      this.MAXIMUM_ANIMATION_JUMP_SECONDS * this.timerService.speedSignal()
     ) {
       // Accelerate to catch up
-      this.animationVisualizationTime +=
-        desynchronizationDifference * (1 - Math.exp(-5 * elapsedTime));
+      const direction = Math.sign(desynchronizationDifference);
+      const absoluteDifference = Math.abs(desynchronizationDifference);
+      const catchUp =
+        this.timerService.speedSignal() * this.MAXIMUM_ANIMATION_JUMP_SECONDS +
+        (absoluteDifference - this.MAXIMUM_ANIMATION_JUMP_SECONDS) *
+          (1 - Math.exp(-5 * elapsedTime));
+
+      this.animationVisualizationTime += catchUp * direction;
     } else {
       this.animationVisualizationTime = visualizationTime;
     }

--- a/multimodal-ui/src/app/services/animation.service.ts
+++ b/multimodal-ui/src/app/services/animation.service.ts
@@ -77,7 +77,6 @@ export class AnimationService {
 
   // Use two variables to avoid changing the ones used for the animation during the animation
   private nextPolylines: AllPolylines | null = null;
-  private nextIsPaused = false;
   private nextFilters: Set<string> = new Set<string>();
   private nextFilterMode: EntityFilterMode = 'all';
   private nextShouldShowComplete = false;
@@ -92,8 +91,6 @@ export class AnimationService {
   private polylines: AllPolylines | null = null;
 
   private hasCenteredInitially = false;
-
-  private isPaused = false;
 
   private vehicleEntities: AnimatedVehicle[] = [];
   private vehicleEntitiesByVehicleId: Record<string, AnimatedVehicle> = {};
@@ -191,10 +188,6 @@ export class AnimationService {
   }
 
   // MARK: Setters
-  setPause(pause: boolean) {
-    this.nextIsPaused = pause;
-  }
-
   setFilters(filters: Set<string>) {
     this.nextFilters = filters;
   }
@@ -261,7 +254,6 @@ export class AnimationService {
 
   clearAnimations() {
     this.nextPolylines = null;
-    this.nextIsPaused = false;
     this.nextFilters.clear();
     this.nextFilterMode = 'all';
     this.nextShouldShowComplete = false;
@@ -275,8 +267,6 @@ export class AnimationService {
     this.polylines = null;
 
     this.hasCenteredInitially = false;
-
-    this.isPaused = false;
 
     this.vehicleEntities = [];
     this.vehicleEntitiesByVehicleId = {};
@@ -363,7 +353,6 @@ export class AnimationService {
     if (!this.fontsLoaded) return;
 
     this.polylines = this.nextPolylines;
-    this.isPaused = this.nextIsPaused;
     this.filters = this.nextFilters;
     this.filterMode = this.nextFilterMode;
     this.shouldShowComplete = this.nextShouldShowComplete;
@@ -431,7 +420,7 @@ export class AnimationService {
       return;
     }
 
-    if (this.isPaused) {
+    if (this.timerService.isPausedSignal()) {
       this.animationVisualizationTime = visualizationTime; // Jump to wanted time
       return;
     }
@@ -441,7 +430,7 @@ export class AnimationService {
 
     if (
       Math.abs(desynchronizationDifference) >
-      this.MAXIMUM_ANIMATION_JUMP * this.timerService.speed
+      this.MAXIMUM_ANIMATION_JUMP * this.timerService.speedSignal()
     ) {
       // Accelerate to catch up
       this.animationVisualizationTime +=

--- a/multimodal-ui/src/app/services/animation.service.ts
+++ b/multimodal-ui/src/app/services/animation.service.ts
@@ -51,7 +51,7 @@ import { TimerService } from './timer.service';
 })
 export class AnimationService {
   // MARK: Constants
-  private readonly MAXIMUM_ANIMATION_JUMP = 30 / 1000; // ms
+  private readonly MAXIMUM_ANIMATION_JUMP = 30 / 1000; // 0.03 seconds (30 ms)
 
   private readonly WHITE = 0xffffff;
 

--- a/multimodal-ui/src/app/services/animation.service.ts
+++ b/multimodal-ui/src/app/services/animation.service.ts
@@ -430,13 +430,17 @@ export class AnimationService {
 
     if (
       Math.abs(desynchronizationDifference) >
-      this.MAXIMUM_ANIMATION_JUMP_SECONDS * this.timerService.speedSignal()
+      Math.abs(
+        this.MAXIMUM_ANIMATION_JUMP_SECONDS * this.timerService.speedSignal(),
+      )
     ) {
       // Accelerate to catch up
       const direction = Math.sign(desynchronizationDifference);
       const absoluteDifference = Math.abs(desynchronizationDifference);
       const catchUp =
-        this.timerService.speedSignal() * this.MAXIMUM_ANIMATION_JUMP_SECONDS +
+        Math.abs(
+          this.timerService.speedSignal() * this.MAXIMUM_ANIMATION_JUMP_SECONDS,
+        ) +
         (absoluteDifference - this.MAXIMUM_ANIMATION_JUMP_SECONDS) *
           (1 - Math.exp(-5 * elapsedTime));
 

--- a/multimodal-ui/src/app/services/timer.service.ts
+++ b/multimodal-ui/src/app/services/timer.service.ts
@@ -81,6 +81,8 @@ export class TimerService {
 
       if (activeSimulation !== null) {
         this.load(activeSimulation.id);
+      } else {
+        this.reset();
       }
     });
 
@@ -263,6 +265,21 @@ export class TimerService {
   }
 
   // MARK: Local Storage
+  private reset(): void {
+    this.nextIsPaused = null;
+    this.nextIsLoading = null;
+    this.nextSpeedPower = null;
+    this.nextDirection = null;
+    this._isPausedSignal.set(null);
+    this._isLoadingSignal.set(null);
+    this._speedPowerSignal.set(null);
+    this._directionSignal.set(null);
+    this._visualizationTime = null;
+    this.isEnvironmentLoaded = false;
+    this._continuousEnvironments = [];
+    this.lastUpdateTime = null;
+  }
+
   private load(simulationId: string): void {
     const isPaused = getVisualizationIsPausedLocalStorage(simulationId);
 

--- a/multimodal-ui/src/app/services/timer.service.ts
+++ b/multimodal-ui/src/app/services/timer.service.ts
@@ -277,7 +277,7 @@ export class TimerService {
     if (speedPower !== null) {
       this.speedPower = speedPower;
     } else {
-      this.speedPower = 1;
+      this.speedPower = 0;
     }
 
     const direction = getVisualizationDirectionLocalStorage(simulationId);

--- a/multimodal-ui/src/app/services/timer.service.ts
+++ b/multimodal-ui/src/app/services/timer.service.ts
@@ -1,0 +1,126 @@
+import { Injectable } from '@angular/core';
+import {
+  ContinuousEnvironment,
+  findClosestContinuousEnvironment,
+} from '../interfaces/continuous.model';
+import { RUNNING_SIMULATION_STATUSES } from '../interfaces/simulation.model';
+import { SimulationService } from './simulation.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TimerService {
+  private readonly MIN_FRAME_RATE = 10; // Hz
+  private readonly MAX_TIME_STEP = 1 / this.MIN_FRAME_RATE; // seconds
+  private _visualizationTime: number | null = null;
+  private isEnvironmentLoaded = false;
+  private _continuousEnvironments: ContinuousEnvironment[] = [];
+
+  private lastUpdateTime: number | null = null;
+
+  isPaused = false;
+  isLoading = false;
+  speed = 1;
+
+  constructor(private readonly simulationService: SimulationService) {}
+
+  get visualizationTime(): number | null {
+    return this._visualizationTime;
+  }
+
+  get continuousEnvironments(): ContinuousEnvironment[] {
+    return this._continuousEnvironments;
+  }
+
+  /**
+   *
+   * @returns The elapsed time in seconds since the last update, or null if there is no active simulation.
+   */
+  updateTime(visualizationTimeOverride?: number): number | null {
+    const { visualizationTime, elapsedTime } = this.updateTimeAtomic(
+      visualizationTimeOverride,
+    );
+
+    if (visualizationTime === null || elapsedTime === null) {
+      this.isEnvironmentLoaded = false;
+      this._visualizationTime = null;
+      return null;
+    }
+
+    const continuousEnvironments =
+      this.simulationService.continuousEnvironmentsSignal();
+
+    this._continuousEnvironments = continuousEnvironments;
+
+    const closestContinuousEnvironment = findClosestContinuousEnvironment(
+      continuousEnvironments,
+      visualizationTime,
+    );
+
+    this.isEnvironmentLoaded = !!closestContinuousEnvironment;
+
+    this._visualizationTime = visualizationTime;
+
+    return elapsedTime;
+  }
+
+  private updateTimeAtomic(visualizationTimeOverride?: number): {
+    visualizationTime: number | null;
+    elapsedTime: number | null;
+  } {
+    const simulation = this.simulationService.activeSimulationSignal();
+
+    if (simulation === null) {
+      this.lastUpdateTime = null;
+      this.isPaused = false;
+      this.isLoading = false;
+      this.speed = 1;
+      return { visualizationTime: null, elapsedTime: null };
+    }
+
+    const simulationStartTime = simulation.simulationStartTime;
+    const visualizationMaxTime = RUNNING_SIMULATION_STATUSES.includes(
+      simulation.status,
+    )
+      ? (simulation.simulationTime ?? simulation.simulationStartTime)
+      : simulation.simulationEndTime;
+
+    if (simulationStartTime === null || visualizationMaxTime === null) {
+      return { visualizationTime: null, elapsedTime: null };
+    }
+
+    const now = performance.now();
+    const lastUpdateTime = this.lastUpdateTime ?? now;
+    this.lastUpdateTime = now;
+    const elapsedTime = Math.min(
+      (now - lastUpdateTime) / 1000,
+      this.MAX_TIME_STEP,
+    );
+
+    if (visualizationTimeOverride !== undefined) {
+      const visualizationTime = Math.max(
+        Math.min(visualizationMaxTime, visualizationTimeOverride),
+        simulationStartTime,
+      );
+      return { visualizationTime, elapsedTime };
+    }
+
+    if (this._visualizationTime === null) {
+      return { visualizationTime: simulationStartTime, elapsedTime };
+    }
+
+    if (this.isLoading || this.isPaused || !this.isEnvironmentLoaded) {
+      return { visualizationTime: this._visualizationTime, elapsedTime };
+    }
+
+    const visualizationTime = Math.min(
+      visualizationMaxTime,
+      Math.max(
+        this._visualizationTime + elapsedTime * this.speed,
+        simulationStartTime,
+      ),
+    );
+
+    return { visualizationTime, elapsedTime };
+  }
+}

--- a/multimodal-ui/src/app/services/timer.service.ts
+++ b/multimodal-ui/src/app/services/timer.service.ts
@@ -1,8 +1,25 @@
-import { Injectable } from '@angular/core';
+import {
+  computed,
+  effect,
+  Injectable,
+  Signal,
+  signal,
+  WritableSignal,
+} from '@angular/core';
 import {
   ContinuousEnvironment,
   findClosestContinuousEnvironment,
 } from '../interfaces/continuous.model';
+import {
+  getVisualizationDirectionLocalStorage,
+  getVisualizationIsPausedLocalStorage,
+  getVisualizationSpeedPowerLocalStorage,
+  getVisualizationTimeLocalStorage,
+  setVisualizationDirectionLocalStorage,
+  setVisualizationIsPausedLocalStorage,
+  setVisualizationSpeedPowerLocalStorage,
+  setVisualizationTimeLocalStorage,
+} from '../interfaces/local-storage';
 import { RUNNING_SIMULATION_STATUSES } from '../interfaces/simulation.model';
 import { SimulationService } from './simulation.service';
 
@@ -10,6 +27,7 @@ import { SimulationService } from './simulation.service';
   providedIn: 'root',
 })
 export class TimerService {
+  // MARK: Properties
   private readonly MIN_FRAME_RATE = 10; // Hz
   private readonly MAX_TIME_STEP = 1 / this.MIN_FRAME_RATE; // seconds
   private _visualizationTime: number | null = null;
@@ -18,12 +36,97 @@ export class TimerService {
 
   private lastUpdateTime: number | null = null;
 
-  isPaused = false;
-  isLoading = false;
-  speed = 1;
+  private nextIsPaused: boolean | null = null;
+  private nextIsLoading: boolean | null = null;
+  private nextSpeedPower: number | null = null;
+  private nextDirection: number | null = null;
 
-  constructor(private readonly simulationService: SimulationService) {}
+  private readonly _isPausedSignal: WritableSignal<boolean | null> =
+    signal(null);
+  private readonly _isLoadingSignal: WritableSignal<boolean | null> =
+    signal(null);
+  private readonly _speedPowerSignal: WritableSignal<number | null> =
+    signal(null);
+  private readonly _directionSignal: WritableSignal<number | null> =
+    signal(null);
 
+  readonly isPausedSignal: Signal<boolean> = computed(
+    () => this._isPausedSignal() === true,
+  );
+  readonly isLoadingSignal: Signal<boolean> = computed(
+    () => this._isLoadingSignal() === true,
+  );
+  readonly speedPowerSignal: Signal<number> = computed(
+    () => this._speedPowerSignal() ?? 0,
+  );
+  readonly directionSignal: Signal<number> = computed(
+    () => this._directionSignal() ?? 1,
+  );
+
+  readonly speedSignal = computed(() => {
+    const speedPower = this._speedPowerSignal();
+    const direction = this._directionSignal();
+
+    if (speedPower === null || direction === null) {
+      return 0;
+    }
+
+    return Math.pow(2, speedPower) * direction;
+  });
+
+  // MARK: Constructor
+  constructor(private readonly simulationService: SimulationService) {
+    effect(() => {
+      const activeSimulation = this.simulationService.activeSimulationSignal();
+
+      if (activeSimulation !== null) {
+        this.load(activeSimulation.id);
+      }
+    });
+
+    effect(() => {
+      const activeSimulation = this.simulationService.activeSimulationSignal();
+
+      if (activeSimulation !== null) {
+        this.saveIsPaused(activeSimulation.id);
+      }
+    });
+
+    effect(() => {
+      const activeSimulation = this.simulationService.activeSimulationSignal();
+
+      if (activeSimulation !== null) {
+        this.saveSpeedPower(activeSimulation.id);
+      }
+    });
+
+    effect(() => {
+      const activeSimulation = this.simulationService.activeSimulationSignal();
+
+      if (activeSimulation !== null) {
+        this.saveDirection(activeSimulation.id);
+      }
+    });
+  }
+
+  // MARK: Setters
+  set isPaused(value: boolean) {
+    this.nextIsPaused = value;
+  }
+
+  set isLoading(value: boolean) {
+    this.nextIsLoading = value;
+  }
+
+  set speedPower(value: number) {
+    this.nextSpeedPower = value;
+  }
+
+  set direction(value: number) {
+    this.nextDirection = value;
+  }
+
+  // MARK: Getters
   get visualizationTime(): number | null {
     return this._visualizationTime;
   }
@@ -32,18 +135,50 @@ export class TimerService {
     return this._continuousEnvironments;
   }
 
+  // MARK: Time Update
   /**
    *
    * @returns The elapsed time in seconds since the last update, or null if there is no active simulation.
    */
   updateTime(visualizationTimeOverride?: number): number | null {
+    if (this.nextIsPaused !== null) {
+      this._isPausedSignal.set(this.nextIsPaused);
+      this.nextIsPaused = null;
+    }
+
+    if (this.nextIsLoading !== null) {
+      this._isLoadingSignal.set(this.nextIsLoading);
+      this.nextIsLoading = null;
+    }
+
+    if (this.nextSpeedPower !== null) {
+      this._speedPowerSignal.set(this.nextSpeedPower);
+      this.nextSpeedPower = null;
+    }
+
+    if (this.nextDirection !== null) {
+      this._directionSignal.set(this.nextDirection);
+      this.nextDirection = null;
+    }
+
     const { visualizationTime, elapsedTime } = this.updateTimeAtomic(
       visualizationTimeOverride,
     );
 
-    if (visualizationTime === null || elapsedTime === null) {
+    const activeSimulation = this.simulationService.activeSimulationSignal();
+
+    if (
+      visualizationTime === null ||
+      elapsedTime === null ||
+      activeSimulation === null
+    ) {
       this.isEnvironmentLoaded = false;
       this._visualizationTime = null;
+
+      if (activeSimulation !== null) {
+        this.saveTime(activeSimulation.id);
+      }
+
       return null;
     }
 
@@ -61,6 +196,8 @@ export class TimerService {
 
     this._visualizationTime = visualizationTime;
 
+    this.saveTime(activeSimulation.id);
+
     return elapsedTime;
   }
 
@@ -72,9 +209,6 @@ export class TimerService {
 
     if (simulation === null) {
       this.lastUpdateTime = null;
-      this.isPaused = false;
-      this.isLoading = false;
-      this.speed = 1;
       return { visualizationTime: null, elapsedTime: null };
     }
 
@@ -109,18 +243,84 @@ export class TimerService {
       return { visualizationTime: simulationStartTime, elapsedTime };
     }
 
-    if (this.isLoading || this.isPaused || !this.isEnvironmentLoaded) {
+    if (
+      this.isLoadingSignal() ||
+      this.isPausedSignal() ||
+      !this.isEnvironmentLoaded
+    ) {
       return { visualizationTime: this._visualizationTime, elapsedTime };
     }
 
     const visualizationTime = Math.min(
       visualizationMaxTime,
       Math.max(
-        this._visualizationTime + elapsedTime * this.speed,
+        this._visualizationTime + elapsedTime * this.speedSignal(),
         simulationStartTime,
       ),
     );
 
     return { visualizationTime, elapsedTime };
+  }
+
+  // MARK: Local Storage
+  private load(simulationId: string): void {
+    const isPaused = getVisualizationIsPausedLocalStorage(simulationId);
+
+    if (isPaused !== null) {
+      this.isPaused = isPaused;
+    } else {
+      this.isPaused = false;
+    }
+
+    const speedPower = getVisualizationSpeedPowerLocalStorage(simulationId);
+
+    if (speedPower !== null) {
+      this.speedPower = speedPower;
+    } else {
+      this.speedPower = 1;
+    }
+
+    const direction = getVisualizationDirectionLocalStorage(simulationId);
+
+    if (direction !== null) {
+      this.direction = direction;
+    } else {
+      this.direction = 1;
+    }
+
+    const time = getVisualizationTimeLocalStorage(simulationId);
+
+    if (time !== null) {
+      this._visualizationTime = time;
+    } else {
+      this._visualizationTime = null;
+    }
+  }
+
+  private saveIsPaused(simulationId: string): void {
+    const isPaused = this._isPausedSignal();
+    if (isPaused !== null) {
+      setVisualizationIsPausedLocalStorage(simulationId, isPaused);
+    }
+  }
+
+  private saveSpeedPower(simulationId: string): void {
+    const speedPower = this._speedPowerSignal();
+    if (speedPower !== null) {
+      setVisualizationSpeedPowerLocalStorage(simulationId, speedPower);
+    }
+  }
+
+  private saveDirection(simulationId: string): void {
+    const direction = this._directionSignal();
+    if (direction !== null) {
+      setVisualizationDirectionLocalStorage(simulationId, direction);
+    }
+  }
+
+  private saveTime(simulationId: string): void {
+    if (this._visualizationTime !== null) {
+      setVisualizationTimeLocalStorage(simulationId, this._visualizationTime);
+    }
   }
 }

--- a/multimodal-ui/src/app/services/timer.service.ts
+++ b/multimodal-ui/src/app/services/timer.service.ts
@@ -138,7 +138,7 @@ export class TimerService {
   // MARK: Time Update
   /**
    *
-   * @returns The elapsed time in seconds since the last update, or null if there is no active simulation.
+   * @returns The elapsed time in seconds since the last update, or null if the visualization time could not be updated.
    */
   updateTime(visualizationTimeOverride?: number): number | null {
     if (this.nextIsPaused !== null) {

--- a/multimodal-ui/src/app/services/visualization.service.ts
+++ b/multimodal-ui/src/app/services/visualization.service.ts
@@ -21,17 +21,13 @@ import {
 } from '../interfaces/simulation.model';
 import { AnimationService } from './animation.service';
 import { SimulationService } from './simulation.service';
+import { TimerService } from './timer.service';
 
 @Injectable()
 export class VisualizationService {
   // MARK: Properties
-
-  private speed = 1;
-
-  private tick = -1;
   private readonly tickSignal: WritableSignal<number> = signal<number>(0);
   private updateTickTimeout: number | null = null;
-  private lastUpdateTickTime = performance.now();
 
   private readonly ENVIRONMENT_TICK_INTERVAL = 1000;
   private readonly environmentTickSignal: WritableSignal<number> =
@@ -45,17 +41,15 @@ export class VisualizationService {
   private readonly _visualizationMaxTimeSignal: WritableSignal<number | null> =
     signal<number | null>(null);
 
+  private readonly _isLoadingSignal: WritableSignal<boolean> = signal(true);
   private readonly _isVisualizationPausedSignal = signal<boolean>(false);
 
-  // MARK: +- Time Logic
-  private visualizationTimeOverride: number | null = null;
-  private readonly visualizationTimeOverrideSignal: WritableSignal<
-    number | null
-  > = signal<number | null>(null);
-
-  private wantedVisualizationTime: number | null = null;
   private readonly _wantedVisualizationTimeSignal: Signal<number | null> =
-    computed(() => this.computeWantedVisualizationTime());
+    computed(() => {
+      this.tickSignal();
+
+      return this.timerService.visualizationTime;
+    });
 
   private environmentSlice: EnvironmentSlice | null = null;
   readonly environmentSignal: Signal<EnvironmentSlice | null> = computed(() =>
@@ -69,6 +63,7 @@ export class VisualizationService {
 
       return this._wantedVisualizationTimeSignal();
     });
+
   private controlledContinuousEnvironmentsSignal: Signal<
     ContinuousEnvironment[]
   > = computed(() => {
@@ -77,19 +72,13 @@ export class VisualizationService {
     return this.simulationService.continuousEnvironmentsSignal();
   });
 
-  private readonly _isLoadingSignal: WritableSignal<boolean> = signal(true);
-
   // MARK: Constructor
   constructor(
     private readonly injector: Injector,
     private readonly simulationService: SimulationService,
     private readonly animationService: AnimationService,
+    private readonly timerService: TimerService,
   ) {
-    effect(() => {
-      const wantedVisualizationTime = this._wantedVisualizationTimeSignal();
-      this.wantedVisualizationTime = wantedVisualizationTime;
-    });
-
     effect(() => {
       const environmentSlice = this.environmentSignal();
       this.environmentSlice = environmentSlice;
@@ -158,25 +147,18 @@ export class VisualizationService {
       }
     });
 
-    this.initializeAutoSave();
-    this.initializeAutoLoad();
+    // MARK: Timer
+    effect(() => {
+      const isPaused = this._isVisualizationPausedSignal();
+      this.timerService.isPaused = isPaused;
+    });
+
+    effect(() => {
+      const isLoading = this._isLoadingSignal();
+      this.timerService.isLoading = isLoading;
+    });
 
     // MARK: Animation
-    effect(() => {
-      const continuousEnvironments =
-        this.simulationService.continuousEnvironmentsSignal();
-
-      this.animationService.updateEnvironment(continuousEnvironments);
-    });
-
-    effect(() => {
-      const wantedVisualizationTime = this._wantedVisualizationTimeSignal();
-
-      this.animationService.updateWantedVisualizationTime(
-        wantedVisualizationTime,
-      );
-    });
-
     effect(() => {
       const polylines = this.simulationService.simulationPolylinesSignal();
       const simulation = this.simulationService.activeSimulationSignal();
@@ -194,60 +176,43 @@ export class VisualizationService {
   }
 
   // MARK: Local Storage
-  private initializeAutoSave(): void {
-    window.addEventListener('beforeunload', () => {
-      this.saveLocalStorageData();
-    });
-  }
+  // private saveLocalStorageData(): void {
+  //   const wantedVisualizationTime = this._wantedVisualizationTimeSignal();
+  //   const isVisualizationPaused = this._isVisualizationPausedSignal();
 
-  private saveLocalStorageData(): void {
-    const wantedVisualizationTime = this._wantedVisualizationTimeSignal();
-    const isVisualizationPaused = this._isVisualizationPausedSignal();
+  //   if (wantedVisualizationTime !== null) {
+  //     localStorage.setItem(
+  //       'wantedVisualizationTime',
+  //       wantedVisualizationTime.toString(),
+  //     );
+  //   }
+  //   localStorage.setItem(
+  //     'isVisualizationPaused',
+  //     JSON.stringify(isVisualizationPaused),
+  //   );
+  // }
 
-    if (wantedVisualizationTime !== null) {
-      localStorage.setItem(
-        'wantedVisualizationTime',
-        wantedVisualizationTime.toString(),
-      );
-    }
-    localStorage.setItem(
-      'isVisualizationPaused',
-      JSON.stringify(isVisualizationPaused),
-    );
-  }
+  // private loadWantedVisualizationTime(): void {
+  //   const savedWantedVisualizationTime = localStorage.getItem(
+  //     'wantedVisualizationTime',
+  //   );
+  //   const savedIsVisualizationPaused = localStorage.getItem(
+  //     'isVisualizationPaused',
+  //   );
 
-  private initializeAutoLoad(): void {
-    window.addEventListener('load', () => {
-      this.loadWantedVisualizationTime();
-    });
-  }
+  //   if (savedWantedVisualizationTime) {
+  //     const time = parseFloat(savedWantedVisualizationTime);
+  //     if (!isNaN(time)) {
+  //       this.wantedVisualizationTime = time;
+  //       this.visualizationTimeOverrideSignal.set(time);
+  //     }
+  //   }
 
-  private loadWantedVisualizationTime(): void {
-    const savedWantedVisualizationTime = localStorage.getItem(
-      'wantedVisualizationTime',
-    );
-    const savedIsVisualizationPaused = localStorage.getItem(
-      'isVisualizationPaused',
-    );
-
-    if (savedWantedVisualizationTime) {
-      const time = parseFloat(savedWantedVisualizationTime);
-      if (!isNaN(time)) {
-        this.wantedVisualizationTime = time;
-        this.visualizationTimeOverrideSignal.set(time);
-      }
-    }
-
-    if (savedIsVisualizationPaused !== null) {
-      const isPaused = JSON.parse(savedIsVisualizationPaused) as boolean;
-      this._isVisualizationPausedSignal.set(isPaused);
-    }
-  }
-
-  public clearLocalStorage(): void {
-    localStorage.removeItem('wantedVisualizationTime');
-    localStorage.removeItem('isVisualizationPaused');
-  }
+  //   if (savedIsVisualizationPaused !== null) {
+  //     const isPaused = JSON.parse(savedIsVisualizationPaused) as boolean;
+  //     this._isVisualizationPausedSignal.set(isPaused);
+  //   }
+  // }
 
   // MARK: Lifecycle
   init(simulation: Simulation) {
@@ -287,7 +252,6 @@ export class VisualizationService {
     this._simulationStartTimeSignal.set(null);
     this._simulationEndTimeSignal.set(null);
     this._visualizationMaxTimeSignal.set(null);
-    this.clearLocalStorage();
 
     if (this.updateTickTimeout !== null) {
       clearTimeout(this.updateTickTimeout);
@@ -344,11 +308,12 @@ export class VisualizationService {
   }
 
   setVisualizationTime(time: number) {
-    this.visualizationTimeOverrideSignal.set(time);
+    this.timerService.updateTime(time);
+    this.tickSignal.update((tick) => tick + 1);
   }
 
   setVisualizationSpeed(speed: number) {
-    this.speed = speed;
+    this.timerService.speed = speed;
   }
 
   // MARK: Private Methods
@@ -373,62 +338,6 @@ export class VisualizationService {
   }
 
   // MARK: Computed signals
-  private computeWantedVisualizationTime(): number | null {
-    const simulationStartTime = this.simulationStartTimeSignal();
-    const visualizationMaxTime = this.visualizationMaxTimeSignal();
-
-    if (simulationStartTime === null || visualizationMaxTime === null) {
-      return null;
-    }
-
-    const isLoading = this._isLoadingSignal();
-    const tick = this.tickSignal();
-    const visualizationTimeOverride = this.visualizationTimeOverrideSignal();
-    const isVisualizationPaused = this.isVisualizationPausedSignal();
-
-    const now = performance.now();
-    const lastUpdateTickTime = this.lastUpdateTickTime;
-    this.lastUpdateTickTime = now;
-
-    if (this.wantedVisualizationTime === null) {
-      return simulationStartTime;
-    }
-
-    if (
-      visualizationTimeOverride !== this.visualizationTimeOverride &&
-      visualizationTimeOverride !== null
-    ) {
-      this.visualizationTimeOverride = visualizationTimeOverride;
-      return Math.max(
-        Math.min(visualizationMaxTime, visualizationTimeOverride),
-        simulationStartTime,
-      );
-    }
-
-    if (isLoading) {
-      return this.wantedVisualizationTime;
-    }
-
-    if (tick === this.tick) {
-      return this.wantedVisualizationTime;
-    }
-
-    this.tick = tick;
-
-    if (isVisualizationPaused) {
-      return this.wantedVisualizationTime;
-    }
-
-    return Math.min(
-      visualizationMaxTime,
-      Math.max(
-        this.wantedVisualizationTime +
-          ((now - lastUpdateTickTime) / 1000) * this.speed,
-        simulationStartTime,
-      ),
-    );
-  }
-
   private sliceEnvironment(): EnvironmentSlice | null {
     this.environmentTickSignal();
 

--- a/multimodal-ui/src/app/services/visualization.service.ts
+++ b/multimodal-ui/src/app/services/visualization.service.ts
@@ -41,9 +41,6 @@ export class VisualizationService {
   private readonly _visualizationMaxTimeSignal: WritableSignal<number | null> =
     signal<number | null>(null);
 
-  private readonly _isLoadingSignal: WritableSignal<boolean> = signal(true);
-  private readonly _isVisualizationPausedSignal = signal<boolean>(false);
-
   private readonly _wantedVisualizationTimeSignal: Signal<number | null> =
     computed(() => {
       this.tickSignal();
@@ -88,21 +85,21 @@ export class VisualizationService {
       const hasAllStates = this.simulationService.hasAllStatesSignal();
 
       if (hasAllStates) {
-        this._isLoadingSignal.set(false);
+        this.timerService.isLoading = false;
         return;
       }
 
       const simulation = this.simulationService.activeSimulationSignal();
 
       if (simulation === null) {
-        this._isLoadingSignal.set(true);
+        this.timerService.isLoading = true;
         return;
       }
 
       const wantedVisualizationTime = this._wantedVisualizationTimeSignal();
 
       if (wantedVisualizationTime === null) {
-        this._isLoadingSignal.set(true);
+        this.timerService.isLoading = true;
         return;
       }
 
@@ -126,7 +123,7 @@ export class VisualizationService {
 
       const environmentSlice = this.environmentSignal();
 
-      this._isLoadingSignal.set(environmentSlice === null);
+      this.timerService.isLoading = environmentSlice === null;
     });
 
     effect(() => {
@@ -147,17 +144,6 @@ export class VisualizationService {
       }
     });
 
-    // MARK: Timer
-    effect(() => {
-      const isPaused = this._isVisualizationPausedSignal();
-      this.timerService.isPaused = isPaused;
-    });
-
-    effect(() => {
-      const isLoading = this._isLoadingSignal();
-      this.timerService.isLoading = isLoading;
-    });
-
     // MARK: Animation
     effect(() => {
       const polylines = this.simulationService.simulationPolylinesSignal();
@@ -174,45 +160,6 @@ export class VisualizationService {
       this.animationService.updatePolylines(polylines);
     });
   }
-
-  // MARK: Local Storage
-  // private saveLocalStorageData(): void {
-  //   const wantedVisualizationTime = this._wantedVisualizationTimeSignal();
-  //   const isVisualizationPaused = this._isVisualizationPausedSignal();
-
-  //   if (wantedVisualizationTime !== null) {
-  //     localStorage.setItem(
-  //       'wantedVisualizationTime',
-  //       wantedVisualizationTime.toString(),
-  //     );
-  //   }
-  //   localStorage.setItem(
-  //     'isVisualizationPaused',
-  //     JSON.stringify(isVisualizationPaused),
-  //   );
-  // }
-
-  // private loadWantedVisualizationTime(): void {
-  //   const savedWantedVisualizationTime = localStorage.getItem(
-  //     'wantedVisualizationTime',
-  //   );
-  //   const savedIsVisualizationPaused = localStorage.getItem(
-  //     'isVisualizationPaused',
-  //   );
-
-  //   if (savedWantedVisualizationTime) {
-  //     const time = parseFloat(savedWantedVisualizationTime);
-  //     if (!isNaN(time)) {
-  //       this.wantedVisualizationTime = time;
-  //       this.visualizationTimeOverrideSignal.set(time);
-  //     }
-  //   }
-
-  //   if (savedIsVisualizationPaused !== null) {
-  //     const isPaused = JSON.parse(savedIsVisualizationPaused) as boolean;
-  //     this._isVisualizationPausedSignal.set(isPaused);
-  //   }
-  // }
 
   // MARK: Lifecycle
   init(simulation: Simulation) {
@@ -286,34 +233,14 @@ export class VisualizationService {
     return this._visualizationMaxTimeSignal;
   }
 
-  get isVisualizationPausedSignal(): Signal<boolean> {
-    return this._isVisualizationPausedSignal;
-  }
-
   get wantedVisualizationTimeSignal(): Signal<number | null> {
     return this._wantedVisualizationTimeSignal;
   }
 
-  get isLoadingSignal(): Signal<boolean> {
-    return this._isLoadingSignal;
-  }
-
   // MARK: Handlers
-  pauseVisualization() {
-    this._isVisualizationPausedSignal.set(true);
-  }
-
-  resumeVisualization() {
-    this._isVisualizationPausedSignal.set(false);
-  }
-
   setVisualizationTime(time: number) {
     this.timerService.updateTime(time);
     this.tickSignal.update((tick) => tick + 1);
-  }
-
-  setVisualizationSpeed(speed: number) {
-    this.timerService.speed = speed;
   }
 
   // MARK: Private Methods


### PR DESCRIPTION
# Centralized timer service

## Goal

There are currently two timers in the application : one in the animation service and one in the visualization service. The first one tries to match the second one. However, this can result in desynchronization problems (entities teleporting, more obvious at high speed).

We can solve this by using a single timer.

## Modifications 

- Create a timer service that is now the reference for : 
  - The visualization time.
  - Whether the visualization is paused or not.
  - Whether the environment for the current time is loading or not.
  - The visualization speed and direction.
- Update the time for each animation cycle. 
- Use and update the visualization variables of the timer service everywhere (UI and animation).
- Save all variables in the local storage on changes and load on initialisation.

## Notes

According to my tests, there is still one small issue with this. When pausing, there might me a small desynchronization between the animation and the real time that cause a small teleportation. 

## What to test?

To test if this is working properly, you can : 
- Run/load a relatively big simulation.
- Play with the speed/direction/time/pause and reload to test the local storage.
- Visualize at high speed.