### PR TITLE
Fix entities tab performances

### DIFF
--- a/multimodal-ui/src/app/components/entities-tab/entities-tab.component.css
+++ b/multimodal-ui/src/app/components/entities-tab/entities-tab.component.css
@@ -1,3 +1,5 @@
+@import "../../../styles/color.styles.css";
+
 .clickable {
   cursor: pointer;
   padding: 0.5rem 0;
@@ -14,4 +16,9 @@
 
 .indent {
   padding-left: 24px;
+}
+
+.placeholder {
+  height: 40px;
+  background-color: var(--gray-background-color);
 }

--- a/multimodal-ui/src/app/components/entities-tab/entities-tab.component.html
+++ b/multimodal-ui/src/app/components/entities-tab/entities-tab.component.html
@@ -1,97 +1,97 @@
 <mat-accordion multi="true">
   <mat-expansion-panel>
-    @let passengers = getPassengers();
+    @let passengers = passengersSignal();
     @let numberOfPassengersByStatus = numberOfPassengersByStatusSignal();
+
     <mat-expansion-panel-header>
       <mat-panel-title> Passengers ({{ passengers.length }}) </mat-panel-title>
     </mat-expansion-panel-header>
-    <div class="flex-column gap-0-5-rem">
-      <mat-accordion multi="true">
-        @for (
-          passengerStatusAndCount of numberOfPassengersByStatus;
-          track passengerStatusAndCount.status
-        ) {
-          <mat-expansion-panel>
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                {{ passengerStatusAndCount.status }} ({{
-                  passengerStatusAndCount.count
-                }})
-              </mat-panel-title>
-            </mat-expansion-panel-header>
-            <div class="flex-column gap-0-5-rem">
-              @for (
-                passenger of passengerStatusAndCount.passengers;
-                track passenger.id
-              ) {
-                <div
-                  tabindex="0"
-                  class="clickable indent"
-                  [matTooltip]="'Select passenger'"
-                  [matTooltipPosition]="'after'"
-                  (click)="selectEntity(passenger)"
-                  (mouseenter)="preselectEntity(passenger)"
-                  (mouseleave)="unpreselectEntity()"
-                  (keydown.enter)="selectEntity(passenger)"
-                >
-                  <app-entity-name
-                    [name]="passenger.name"
-                    [tags]="passenger.tags"
-                  />
-                </div>
-              }
-            </div>
-          </mat-expansion-panel>
-        }
-      </mat-accordion>
-    </div>
+
+    <mat-accordion multi="true">
+      @for (
+        passengerStatusAndCount of numberOfPassengersByStatus;
+        track passengerStatusAndCount.status
+      ) {
+        <mat-expansion-panel>
+          <mat-expansion-panel-header>
+            <mat-panel-title>
+              {{ passengerStatusAndCount.status }} ({{
+                passengerStatusAndCount.count
+              }})
+            </mat-panel-title>
+          </mat-expansion-panel-header>
+
+          @for (
+            passenger of passengerStatusAndCount.passengers;
+            track passenger.id
+          ) {
+            @defer (on viewport) {
+              <div
+                tabindex="0"
+                class="clickable indent"
+                [matTooltip]="'Select passenger'"
+                [matTooltipPosition]="'after'"
+                (click)="selectEntity(passenger)"
+                (mouseenter)="preselectEntity(passenger)"
+                (mouseleave)="unpreselectEntity()"
+                (keydown.enter)="selectEntity(passenger)"
+              >
+                <app-entity-name
+                  [name]="passenger.name"
+                  [tags]="passenger.tags"
+                />
+              </div>
+            } @placeholder {
+              <div class="placeholder"></div>
+            }
+          }
+        </mat-expansion-panel>
+      }
+    </mat-accordion>
   </mat-expansion-panel>
 
   <mat-expansion-panel>
-    @let vehicles = getVehicles();
+    @let vehicles = vehiclesSignal();
     @let numberOfVehiclesByStatus = numberOfVehiclesByStatusSignal();
+
     <mat-expansion-panel-header>
       <mat-panel-title> Vehicles ({{ vehicles.length }}) </mat-panel-title>
     </mat-expansion-panel-header>
-    <div class="flex-column gap-0-5-rem">
-      <mat-accordion multi="true">
-        @for (
-          vehicleStatusAndCount of numberOfVehiclesByStatus;
-          track vehicleStatusAndCount.status
-        ) {
-          <mat-expansion-panel>
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                {{ vehicleStatusAndCount.status }} ({{
-                  vehicleStatusAndCount.count
-                }})
-              </mat-panel-title>
-            </mat-expansion-panel-header>
-            <div class="flex-column gap-0-5-rem">
-              @for (
-                vehicle of vehicleStatusAndCount.vehicles;
-                track vehicle.id
-              ) {
-                <div
-                  tabindex="0"
-                  class="clickable indent"
-                  [matTooltip]="'Select vehicle'"
-                  [matTooltipPosition]="'after'"
-                  (click)="selectEntity(vehicle)"
-                  (mouseenter)="preselectEntity(vehicle)"
-                  (mouseleave)="unpreselectEntity()"
-                  (keydown.enter)="selectEntity(vehicle)"
-                >
-                  <app-entity-name
-                    [name]="vehicle.name"
-                    [tags]="vehicle.tags"
-                  />
-                </div>
-              }
-            </div>
-          </mat-expansion-panel>
-        }
-      </mat-accordion>
-    </div>
+
+    <mat-accordion multi="true">
+      @for (
+        vehicleStatusAndCount of numberOfVehiclesByStatus;
+        track vehicleStatusAndCount.status
+      ) {
+        <mat-expansion-panel>
+          <mat-expansion-panel-header>
+            <mat-panel-title>
+              {{ vehicleStatusAndCount.status }} ({{
+                vehicleStatusAndCount.count
+              }})
+            </mat-panel-title>
+          </mat-expansion-panel-header>
+
+          @for (vehicle of vehicleStatusAndCount.vehicles; track vehicle.id) {
+            @defer (on viewport) {
+              <div
+                tabindex="0"
+                class="clickable indent"
+                [matTooltip]="'Select vehicle'"
+                [matTooltipPosition]="'after'"
+                (click)="selectEntity(vehicle)"
+                (mouseenter)="preselectEntity(vehicle)"
+                (mouseleave)="unpreselectEntity()"
+                (keydown.enter)="selectEntity(vehicle)"
+              >
+                <app-entity-name [name]="vehicle.name" [tags]="vehicle.tags" />
+              </div>
+            } @placeholder {
+              <div class="placeholder"></div>
+            }
+          }
+        </mat-expansion-panel>
+      }
+    </mat-accordion>
   </mat-expansion-panel>
 </mat-accordion>

--- a/multimodal-ui/src/app/components/entities-tab/entities-tab.component.ts
+++ b/multimodal-ui/src/app/components/entities-tab/entities-tab.component.ts
@@ -16,12 +16,14 @@ import { EntityNameComponent } from '../entity-name/entity-name.component';
 })
 export class EntitiesTabComponent {
   // MARK: Properties
-  readonly getPassengers: Signal<Passenger[]> = computed(() => {
+  readonly passengersSignal: Signal<Passenger[]> = computed(() => {
     const environment = this.visualizationService.environmentSignal();
+
     if (environment === null) {
       return [];
     }
-    return Object.values(environment.passengers);
+
+    return environment.allPassengers;
   });
 
   readonly numberOfPassengersByStatusSignal: Signal<
@@ -31,21 +33,8 @@ export class EntitiesTabComponent {
       passengers: Passenger[];
     }[]
   > = computed(() => {
-    const environment = this.visualizationService.environmentSignal();
-    if (environment === null) {
-      return [];
-    }
+    const passengers = this.passengersSignal();
 
-    const passengers = Object.values(environment.passengers);
-    passengers.sort(
-      (a, b) =>
-        b.nextLegs.length +
-        b.previousLegs.length +
-        (b.currentLeg != null ? 1 : 0) -
-        (a.nextLegs.length +
-          a.previousLegs.length +
-          (a.currentLeg != null ? 1 : 0)),
-    );
     const counts: Record<string, Passenger[]> = {};
 
     for (const passenger of passengers) {
@@ -61,12 +50,14 @@ export class EntitiesTabComponent {
     }));
   });
 
-  readonly getVehicles: Signal<Vehicle[]> = computed(() => {
+  readonly vehiclesSignal: Signal<Vehicle[]> = computed(() => {
     const environment = this.visualizationService.environmentSignal();
+
     if (environment === null) {
       return [];
     }
-    return Object.values(environment.vehicles);
+
+    return environment.allVehicles;
   });
 
   readonly numberOfVehiclesByStatusSignal: Signal<
@@ -76,13 +67,8 @@ export class EntitiesTabComponent {
       vehicles: Vehicle[];
     }[]
   > = computed(() => {
-    const environment = this.visualizationService.environmentSignal();
+    const vehicles = this.vehiclesSignal();
 
-    if (environment === null) {
-      return [];
-    }
-
-    const vehicles = Object.values(environment.vehicles);
     const counts: Record<string, Vehicle[]> = {};
 
     for (const vehicle of vehicles) {
@@ -98,11 +84,13 @@ export class EntitiesTabComponent {
     }));
   });
 
+  // MARK: Constructor
   constructor(
     private readonly animationService: AnimationService,
     private readonly visualizationService: VisualizationService,
   ) {}
 
+  // MARK: Methods
   preselectEntity(entity: EntityMetadata) {
     this.animationService.preselectEntity(entity, false);
   }

--- a/multimodal-ui/src/app/components/entity-name/entity-name.component.ts
+++ b/multimodal-ui/src/app/components/entity-name/entity-name.component.ts
@@ -7,11 +7,10 @@ import { Component, input, InputSignal } from '@angular/core';
   styleUrl: './entity-name.component.scss',
 })
 export class EntityNameComponent {
-  nameInputSignal: InputSignal<string | null | undefined> = input.required<
-    string | null | undefined
-  >({ alias: 'name' });
+  readonly nameInputSignal: InputSignal<string | null | undefined> =
+    input.required<string | null | undefined>({ alias: 'name' });
 
-  tagsInputSignal: InputSignal<string[] | undefined> = input.required<
+  readonly tagsInputSignal: InputSignal<string[] | undefined> = input.required<
     string[] | undefined
   >({
     alias: 'tags',


### PR DESCRIPTION
# Fix entities tab performances

No significative improvement have been made. The entities tab can be a pretty large element and Angular seems to apply updates each frame to the element. This takes a few milliseconds each frame but can alter the visualization when the animation takes most of the frame time.

## Modifications

- Small code refactor.
- Add defer blocks to only load elements when entering viewport.